### PR TITLE
feat: add generate command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lula
 compliance_report-*
+out/

--- a/src/cmd/execute/execute.go
+++ b/src/cmd/execute/execute.go
@@ -191,26 +191,26 @@ func conductExecute(componentDefinitionPaths []string, resourcePaths []string, d
 func conductGenerate(componentDefinitionPaths []string, outDirectory string) error {
 	err := os.Mkdir(outDirectory, 0755)
 	if err != nil {
-		logrus.Error(err, "error creating output directory")
+		logrus.Error("error creating output directory: ", err)
 		return err
 	}
 
 	oscalComponentDefinitions, err := oscalComponentDefinitionsFromPaths(componentDefinitionPaths)
 	if err != nil {
-		logrus.Error(err, "error getting oscal component definitions")
+		logrus.Error("error getting oscal component definitions: ", err)
 		return err
 	}
 
 	implementedReqs, err := getImplementedReqs(oscalComponentDefinitions)
 	if err != nil {
-		logrus.Error(err, "error getting implemented requirements")
+		logrus.Error("error getting implemented requirements: ", err)
 		return err
 	}
 
 	for _, implementedReq := range implementedReqs {
 		_, err := generatePolicy(implementedReq, outDirectory)
 		if err != nil {
-			logrus.Error(err, "error generating policy")
+			logrus.Error("error generating policy: ", err)
 			return err
 		}
 	}

--- a/src/cmd/execute/execute.go
+++ b/src/cmd/execute/execute.go
@@ -189,7 +189,7 @@ func conductExecute(componentDefinitionPaths []string, resourcePaths []string, d
 }
 
 func conductGenerate(componentDefinitionPaths []string, outDirectory string) error {
-	err := os.Mkdir(outDirectory, 0755)
+	err := os.MkdirAll(outDirectory, 0755)
 	if err != nil {
 		logrus.Error("error creating output directory: ", err)
 		return err

--- a/src/cmd/execute/execute.go
+++ b/src/cmd/execute/execute.go
@@ -266,13 +266,14 @@ func generatePolicy(implementedRequirement types.ImplementedRequirementsCustom, 
 
 	if len(implementedRequirement.Rules) != 0 {
 		// fmt.Printf("%v", implementedRequirement.Rules[0].Validation.RawPattern)
+		policyName := strings.ToLower(implementedRequirement.UUID)
 		policy := v1.ClusterPolicy{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterPolicy",
 				APIVersion: "kyverno.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: implementedRequirement.UUID,
+				Name: policyName,
 			},
 			Spec: v1.Spec{
 				Rules: implementedRequirement.Rules,
@@ -284,7 +285,7 @@ func generatePolicy(implementedRequirement types.ImplementedRequirementsCustom, 
 			fmt.Printf("Error while Marshaling. %v", err)
 		}
 
-		fileName := implementedRequirement.UUID + ".yaml"
+		fileName := policyName + ".yaml"
 		policyPath = path.Join(outDir, fileName)
 		err = ioutil.WriteFile(policyPath, yamlData, 0644)
 		if err != nil {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -16,7 +16,8 @@ var rootCmd = &cobra.Command{
 func Execute() {
 
 	commands := []*cobra.Command{
-		execute.Command(),
+		execute.ExecuteCommand(),
+		execute.GenerateCommand(),
 	}
 
 	rootCmd.AddCommand(commands...)


### PR DESCRIPTION
## Current Behavior

Kyverno policies that are generated for auditing a cluster are deleted after the audit is done

## Proposed Behavior 

This adds a generate command to output the kyverno policies from OCSAL definitions