### PR TITLE
Replace oscal component definition types with go-oscal generated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,25 @@
 
 lula is a tool written to bridge the gap between expected configuration required for compliance and **_actual_** configuration.
 
-Cloud Native Infrastructure, Platforms, and applications can establish OSCAL documents that live beside source-of-truth code bases. Providing an inheritance model for when a control that the technology can satisfy _IS_ satisfied in a live-environment. 
+Cloud Native Infrastructure, Platforms, and applications can establish OSCAL documents that live beside source-of-truth code bases. Providing an inheritance model for when a control that the technology can satisfy _IS_ satisfied in a live-environment.
 
 This can be well established and regulated standards such as NIST 800-53. It can also be best practices, Enterprise Standards, or simply team development standards that need to be continuously monitored and validated.
 
-## Hows it work?
+## How does it work?
+
 The primary functionality is leveraging [Kyverno CLI/Engine](https://kyverno.io/docs/kyverno-cli/).
 lula:
+
 - Ingests a `oscal-component.yaml` and creates an object in memory
 - Queries all `implemented-requirements` for a `rules` field
-    - This rules block is a strict port from the rules of a [Kyverno ClusterPolicy](https://kyverno.io/docs/kyverno-policies/) resource
+  - This rules block is a strict port from the rules of a [Kyverno ClusterPolicy](https://kyverno.io/docs/kyverno-policies/) resource
 - If a rules field exists:
-    - Generate a `ClusterPolicy` resource on the filesystem
-    - Execute the `applyCommandHelper` function from Kyverno CLI
-        - This will return the number of passing/failing resources in the cluster (or optionally static manifests on the filesystem)
-        - If any fail, given valid exclusions that may be present, the control is declared as `Fail`
-    - Remove `ClusterPolicy` from the filesystem
-    - This is done for each `implemented-requirement` that has a `rules` field
+  - Generate a `ClusterPolicy` resource on the filesystem
+  - Execute the `applyCommandHelper` function from Kyverno CLI
+    - This will return the number of passing/failing resources in the cluster (or optionally static manifests on the filesystem)
+    - If any fail, given valid exclusions that may be present, the control is declared as `Fail`
+  - Remove `ClusterPolicy` from the filesystem
+  - This is done for each `implemented-requirement` that has a `rules` field
 - Generate a report of the findings (`Pass` or `fail` for each control) on the filesystem (optional - can be run with `--dry-run` in order to not write to filesystem)
 
 ## Getting Started
@@ -26,33 +28,93 @@ lula:
 ## Demo
 
 ### Static Manifest Demo
+
 ![Resource Demo](./images/resource-demo.gif)
 
 
 ### Live Cluster Demo
+
 ![Cluster Demo](./images/cluster-demo.gif)
 
-### Try it out!
+### Try it out
 
-#### Dependencies:
+#### Dependencies
+
 - A running Kubernetes cluster
 - GoLang version 1.19.1
 
 #### Steps
-1. Clone the repository to your local machine
-2. While in the `lula` directory, run ```go build .``` to compile the tool
-3. Apply the `namespace.yaml` file in the `demo` directory to your cluster using the ```kubectl apply -f ./demo/namespace.yaml``` command
-4. Apply the `pod.fail.yaml` file to your cluster using the ```kubectl apply -f ./demo/pod.fail.yaml``` command
-5. Run the following command in the `lula` directory, ```./lula execute ./demo/oscal-component.yaml```
-    - The tool should inform you that there is at least one failing pod in the cluster
-6. Now, apply the `pod.pass.yaml` file to your cluster using the ```kubectl apply -f ./demo/pod.pass.yaml``` command
-    - This should modify the configuration for the pod to have the validation pass
-7. Run the following command in the `lula` directory, ```./lula execute ./demo/oscal-component.yaml```
-    - The tool should now show the pod as passing the compliance requirement
+
+1. Clone the repository to your local machine and change into the `lula` directory
+
+    ```bash
+    git clone https://github.com/defenseunicorns/lula.git && cd lula
+    ```
+
+1. While in the `lula` directory, compile the tool into an executable binary. This outputs the `lula` binary to the current working directory.
+
+    ```bash
+    go build .
+    ```
+
+1. Apply the `./demo/namespace.yaml` file to create a namespace for the demo
+
+    ```bash
+    kubectl apply -f ./demo/namespace.yaml
+    ```
+
+1. Apply the `./demo/pod.fail.yaml` to create a pod in your cluster
+
+    ```bash
+    kubectl apply -f ./demo/pod.fail.yaml
+    ```
+
+1. Run the following command in the `lula` directory:
+
+    ```bash
+    ./lula execute ./demo/oscal-component.yaml
+    ```
+
+    The output in your terminal should inform you that there is at least one failing pod in the cluster:
+
+    ```bash
+    Applying 1 policy rule to 19 resources...
+
+    policy 42c2ffdc-5f05-44df-a67f-eec8660aeffd -> resource foo/Pod/demo-pod failed: 
+    1. ID-1: validation error: Every pod in namespace 'foo' should have 'foo=bar' label. rule ID-1 failed at path /metadata/labels/foo/ 
+    UUID: 42C2FFDC-5F05-44DF-A67F-EEC8660AEFFD
+            Resources Passing: 0
+            Resources Failing: 1
+            Status: Fail
+    ```
+
+1. Now, apply the `./demo/pod.pass.yaml` file to your cluster to configure the pod to pass compliance validation:
+
+    ```bash
+    kubectl apply -f ./demo/pod.pass.yaml
+    ```
+
+1. Run the following command in the `lula` directory:
+
+    ```bash
+    ./lula execute ./demo/oscal-component.yaml
+    ```
+
+    The output should now show the pod as passing the compliance requirement:
+
+    ```bash
+    Applying 1 policy rule to 19 resources...
+    UUID: 42C2FFDC-5F05-44DF-A67F-EEC8660AEFFD
+            Resources Passing: 1
+            Resources Failing: 0
+            Status: Pass
+    ```
 
 ## Future Extensibility
+
 - Support for cloud infrastructure state queries
 - Support for API validation
 
 ## Developing
-- GO 1.19
+
+- Go 1.19

--- a/src/cmd/execute/execute.go
+++ b/src/cmd/execute/execute.go
@@ -251,7 +251,7 @@ func conductGenerate(componentDefinitionPaths []string, outDirectory string) err
 }
 
 // Open files and attempt to unmarshall to oscal component definition structs
-func oscalComponentDefinitionsFromPaths(filepaths []string) (oscalComponentDefinitions []types.OscalComponentDefinition, err error) {
+func oscalComponentDefinitionsFromPaths(filepaths []string) (oscalComponentDefinitions []types.OscalComponentDefinitionModel, err error) {
 	for _, path := range filepaths {
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
@@ -262,7 +262,7 @@ func oscalComponentDefinitionsFromPaths(filepaths []string) (oscalComponentDefin
 		rawDoc, err := os.ReadFile(path)
 		check(err)
 
-		var oscalComponentDefinition types.OscalComponentDefinition
+		var oscalComponentDefinition types.OscalComponentDefinitionModel
 
 		jsonDoc, err := yaml2.YAMLToJSON(rawDoc)
 		if err != nil {
@@ -281,7 +281,7 @@ func oscalComponentDefinitionsFromPaths(filepaths []string) (oscalComponentDefin
 // Parse the ingested documents (POC = 1) for applicable information
 // Knowns = this will be a yaml file
 // return a slice of Control objects
-func getImplementedReqs(componentDefinitions []types.OscalComponentDefinition) (implementedReqs []types.ImplementedRequirementsCustom, err error) {
+func getImplementedReqs(componentDefinitions []types.OscalComponentDefinitionModel) (implementedReqs []types.ImplementedRequirement, err error) {
 	for _, componentDefinition := range componentDefinitions {
 		for _, component := range componentDefinition.ComponentDefinition.Components {
 			for _, controlImplementation := range component.ControlImplementations {
@@ -295,7 +295,7 @@ func getImplementedReqs(componentDefinitions []types.OscalComponentDefinition) (
 // Turn a ruleset into a ClusterPolicy resource for ability to use Kyverno applyCommandHelper without modification
 // This needs to copy the rules into a Cluster Policy resource (yaml) and write to individual files
 // Kyverno will perform applying these and generating pass/fail results
-func generatePolicy(implementedRequirement types.ImplementedRequirementsCustom, outDir string) (policyPath string, err error) {
+func generatePolicy(implementedRequirement types.ImplementedRequirement, outDir string) (policyPath string, err error) {
 
 	if len(implementedRequirement.Rules) != 0 {
 		// fmt.Printf("%v", implementedRequirement.Rules[0].Validation.RawPattern)

--- a/src/internal/types/types.go
+++ b/src/internal/types/types.go
@@ -1,65 +1,291 @@
+/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate:
+
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs \
+		--pkg <name_of_your_go_package> // defaults to "main"
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+*/
+
+// A couple custom additions were made to this auto-generated file:
+// The ComplianceReport struct was added and the Rules field was added to the ImplementedRequirement struct
+
 package types
 
 import (
 	Kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
-	"time"
 )
 
-type OscalComponentDefinition struct {
-	ComponentDefinition struct {
-		UUID     string `json:"uuid" yaml:"uuid"`
-		Metadata struct {
-			Title        string    `json:"title" yaml:"title"`
-			LastModified time.Time `json:"last-modified" yaml:"last-modified"`
-			Version      string    `json:"version" yaml:"version"`
-			OscalVersion string    `json:"oscal-version" yaml:"oscal-version"`
-			Parties      []struct {
-				UUID  string `json:"uuid" yaml:"uuid"`
-				Type  string `json:"type" yaml:"type"`
-				Name  string `json:"name" yaml:"name"`
-				Links []struct {
-					Href string `json:"href" yaml:"href"`
-					Rel  string `json:"rel" yaml:"rel"`
-				} `json:"links" yaml:"links"`
-			} `json:"parties" yaml:"parties"`
-		} `json:"metadata" yaml:"metadata"`
-		Components []struct {
-			UUID             string `json:"uuid" yaml:"uuid"`
-			Type             string `json:"type" yaml:"type"`
-			Title            string `json:"title" yaml:"title"`
-			Description      string `json:"description" yaml:"description"`
-			Purpose          string `json:"purpose" yaml:"purpose"`
-			ResponsibleRoles []struct {
-				RoleID    string `json:"role-id" yaml:"role-id"`
-				PartyUUIDs []string `json:"party-uuids" yaml:"party-uuids"`
-			} `json:"responsible-roles" yaml:"responsible-roles"`
-			ControlImplementations []struct {
-				UUID                    string                          `json:"uuid" yaml:"uuid"`
-				Source                  string                          `json:"source" yaml:"source"`
-				Description             string                          `json:"description" yaml:"description"`
-				ImplementedRequirements []ImplementedRequirementsCustom `json:"implemented-requirements" yaml:"implemented-requirements"`
-			} `json:"control-implementations" yaml:"control-implementations"`
-		}
-		BackMatter struct {
-			Resources []struct {
-				UUID   string `json:"uuid" yaml:"uuid"`
-				Title  string `json:"title" yaml:"title"`
-				Rlinks []struct {
-					Href string `json:"href" yaml:"href"`
-				} `json:"rlinks" yaml:"rlinks"`
-			} `json:"resources" yaml:"resources"`
-		} `json:"back-matter" yaml:"back-matter"`
-	} `json:"component-definition" yaml:"component-definition"`
+type OscalComponentDefinitionModel struct {
+	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
 }
 
-type ImplementedRequirementsCustom struct {
-	UUID        string         `json:"uuid" yaml:"uuid"`
-	ControlID   string         `json:"control-id" yaml:"control-id"`
-	Description string         `json:"description" yaml:"description"`
-	Rules       []Kyverno.Rule `json:"rules,omitempty" yaml:"rules,omitempty"`
-}
-
+// This struct was manually added to this auto-generated file for generating compliance reports.
 type ComplianceReport struct {
-	SourceRequirements ImplementedRequirementsCustom `json:"source-requirements" yaml:"source-requirements"`
-	Result string `json:"result" yaml:"result"`
+	SourceRequirements ImplementedRequirement `json:"source-requirements" yaml:"source-requirements"`
+	Result             string                 `json:"result" yaml:"result"`
+}
+
+type PortRange struct {
+	Start     int    `json:"start,omitempty" yaml:"start,omitempty"`
+	End       int    `json:"end,omitempty" yaml:"end,omitempty"`
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+type Rlinks struct {
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Hashes    []Hash `json:"hashes,omitempty" yaml:"hashes,omitempty"`
+}
+
+type BackMatter struct {
+	Resources []Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type TelephoneNumber struct {
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+	Number string `json:"number" yaml:"number"`
+}
+
+type ExternalIds struct {
+	Scheme string `json:"scheme" yaml:"scheme"`
+	ID     string `json:"id" yaml:"id"`
+}
+
+type Hash struct {
+	Algorithm string `json:"algorithm" yaml:"algorithm"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Citation struct {
+	Text  string     `json:"text" yaml:"text"`
+	Props []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Links []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+}
+
+type Base64 struct {
+	Filename  string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Location struct {
+	UUID             string            `json:"uuid" yaml:"uuid"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	EmailAddresses   []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	TelephoneNumbers []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Urls             []string          `json:"urls,omitempty" yaml:"urls,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Address          Address           `json:"address" yaml:"address"`
+}
+
+type ResponsibleParty struct {
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+	PartyUuids []string   `json:"party-uuids" yaml:"party-uuids"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+}
+
+type Protocol struct {
+	UUID       string      `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Name       string      `json:"name" yaml:"name"`
+	Title      string      `json:"title,omitempty" yaml:"title,omitempty"`
+	PortRanges []PortRange `json:"port-ranges,omitempty" yaml:"port-ranges,omitempty"`
+}
+
+type Role struct {
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	Props       []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Links       []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Remarks     string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ID          string     `json:"id" yaml:"id"`
+	Title       string     `json:"title" yaml:"title"`
+	ShortName   string     `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+}
+
+type Metadata struct {
+	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
+	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Roles              []Role             `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Version            string             `json:"version" yaml:"version"`
+	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
+	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
+	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
+	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
+	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
+	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	Title              string             `json:"title" yaml:"title"`
+}
+
+type DocumentId struct {
+	Scheme     string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Identifier string `json:"identifier" yaml:"identifier"`
+}
+
+type Resources struct {
+	UUID        string       `json:"uuid" yaml:"uuid"`
+	Title       string       `json:"title,omitempty" yaml:"title,omitempty"`
+	DocumentIds []DocumentId `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Rlinks      []Rlinks     `json:"rlinks,omitempty" yaml:"rlinks,omitempty"`
+	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
+	Props       []Property   `json:"props,omitempty" yaml:"props,omitempty"`
+	Citation    []Citation   `json:"citation,omitempty" yaml:"citation,omitempty"`
+	Base64      []Base64     `json:"base64,omitempty" yaml:"base64,omitempty"`
+	Remarks     string       `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+}
+
+type ResponsibleRole struct {
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids,omitempty" yaml:"party-uuids,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+}
+
+type ImplementedRequirement struct {
+	Description      string            `json:"description" yaml:"description"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	SetParameters    []SetParameter    `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+	ControlId        string            `json:"control-id" yaml:"control-id"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Statements       []Statement       `json:"statements,omitempty" yaml:"statements,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	// This is a custom field for Kyverno rules to generate compliance reports
+	Rules []Kyverno.Rule `json:"rules,omitempty" yaml:"rules,omitempty"`
+}
+
+type ControlImplementation struct {
+	Props                   []Property               `json:"props,omitempty" yaml:"props,omitempty"`
+	Links                   []Link                   `json:"links,omitempty" yaml:"links,omitempty"`
+	SetParameters           []SetParameter           `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	ImplementedRequirements []ImplementedRequirement `json:"implemented-requirements" yaml:"implemented-requirements"`
+	UUID                    string                   `json:"uuid" yaml:"uuid"`
+	Source                  string                   `json:"source" yaml:"source"`
+	Description             string                   `json:"description" yaml:"description"`
+}
+
+type Property struct {
+	Class   string `json:"class,omitempty" yaml:"class,omitempty"`
+	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Name    string `json:"name" yaml:"name"`
+	UUID    string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Ns      string `json:"ns,omitempty" yaml:"ns,omitempty"`
+	Value   string `json:"value" yaml:"value"`
+}
+
+type Revision struct {
+	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
+	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	Version      string     `json:"version" yaml:"version"`
+	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
+}
+
+type DefinedComponent struct {
+	Title                  string                  `json:"title" yaml:"title"`
+	Purpose                string                  `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Protocols              []Protocol              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+	Type                   string                  `json:"type" yaml:"type"`
+	Description            string                  `json:"description" yaml:"description"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	ResponsibleRoles       []ResponsibleRole       `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+}
+
+type Capability struct {
+	Description            string                  `json:"description" yaml:"description"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	IncorporatesComponents []IncorporatesComponent `json:"incorporates-components,omitempty" yaml:"incorporates-components,omitempty"`
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+	Name                   string                  `json:"name" yaml:"name"`
+}
+
+type Address struct {
+	City       string   `json:"city,omitempty" yaml:"city,omitempty"`
+	State      string   `json:"state,omitempty" yaml:"state,omitempty"`
+	PostalCode string   `json:"postal-code,omitempty" yaml:"postal-code,omitempty"`
+	Country    string   `json:"country,omitempty" yaml:"country,omitempty"`
+	Type       string   `json:"type,omitempty" yaml:"type,omitempty"`
+	AddrLines  []string `json:"addr-lines,omitempty" yaml:"addr-lines,omitempty"`
+}
+
+type Party struct {
+	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
+	LocationUuids         []string          `json:"location-uuids,omitempty" yaml:"location-uuids,omitempty"`
+	Remarks               string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                  string            `json:"uuid" yaml:"uuid"`
+	Type                  string            `json:"type" yaml:"type"`
+	ShortName             string            `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	ExternalIds           []ExternalIds     `json:"external-ids,omitempty" yaml:"external-ids,omitempty"`
+	Props                 []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Links                 []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	EmailAddresses        []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	TelephoneNumbers      []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Addresses             []Address         `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	MemberOfOrganizations []string          `json:"member-of-organizations,omitempty" yaml:"member-of-organizations,omitempty"`
+}
+
+type Statement struct {
+	StatementId      string            `json:"statement-id" yaml:"statement-id"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+	Description      string            `json:"description" yaml:"description"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+}
+
+type Link struct {
+	Href      string `json:"href" yaml:"href"`
+	Rel       string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Text      string `json:"text,omitempty" yaml:"text,omitempty"`
+}
+
+type ImportComponentDefinition struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+type ComponentDefinition struct {
+	UUID                       string                      `json:"uuid" yaml:"uuid"`
+	Metadata                   Metadata                    `json:"metadata" yaml:"metadata"`
+	ImportComponentDefinitions []ImportComponentDefinition `json:"import-component-definitions,omitempty" yaml:"import-component-definitions,omitempty"`
+	Components                 []DefinedComponent          `json:"components,omitempty" yaml:"components,omitempty"`
+	Capabilities               []Capability                `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	BackMatter                 BackMatter                  `json:"back-matter,omitempty" yaml:"back-matter,omitempty"`
+}
+
+type SetParameter struct {
+	Remarks string   `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ParamId string   `json:"param-id" yaml:"param-id"`
+	Values  []string `json:"values" yaml:"values"`
+}
+
+type IncorporatesComponent struct {
+	ComponentUuid string `json:"component-uuid" yaml:"component-uuid"`
+	Description   string `json:"description" yaml:"description"`
 }


### PR DESCRIPTION
Relates to https://github.com/defenseunicorns/lula/issues/15
Relates to https://github.com/defenseunicorns/lula/issues/38

Signed-off-by: Lucas Rodriguez <lucas.rodriguez@defenseunicorns.com>

- Replaces oscal component definition types with [go-oscal](https://github.com/defenseunicorns/go-oscal) generated types so that we are using types that are compliant with the oscal schema (kind of, we still have a custom `Rules` field added to the `ImplementedRequirement` struct)

- Updates README.md