### PR TITLE
Policy UUID relation

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -308,10 +308,16 @@ func generatePolicy(implementedRequirement types.ImplementedRequirement, outDir 
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: policyName,
+				Labels: map[string]string{
+					"requirement": policyName,
+					"control-id":  implementedRequirement.ControlId,
+				},
 			},
 			Spec: v1.Spec{
 				Rules: implementedRequirement.Rules,
-			}}
+			},
+		}
+
 		// Requires the use of sigs.k8s.io/yaml for proper marshalling
 		yamlData, err := yaml1.Marshal(&policy)
 

--- a/test/cli/component-definitions/oscal-component.yaml
+++ b/test/cli/component-definitions/oscal-component.yaml
@@ -307,11 +307,6 @@ component-definition:
                 - istio-operator
                 - gatekeeper-system
                 - bigbang
-            - resources:
-                kinds:
-                - deployment
-                - statefulset
-                - daemonset
           validate:
             message: "Every pod should have istio-proxy"
             pattern:


### PR DESCRIPTION
DIscussion at the Policy Working Group today highlighted a need for traceability between a `ClusterPolicy` in the Cluster and the OSCAL that it may have been derived from. 

This labeling can be used by other automation later to aggregate findings for other potential collaboration. This change is mainly to drive discussion and is also low-impact. Wanted to get this through before looking at engine abstraction.

Tested application against a live-cluster to ensure Generate is creating valid ClusterPolicies

Found bug #59 in the process - not within scope to fix here.

Closes #58 