### PR TITLE
chore: add scorecard and codeql workflows

### DIFF
--- a/.github/actions/golang/action.yaml
+++ b/.github/actions/golang/action.yaml
@@ -1,0 +1,10 @@
+name: setup-go
+description: "Setup Go binary and caching"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        go-version: 1.21.x
+        cache: true

--- a/.github/codeql.yaml
+++ b/.github/codeql.yaml
@@ -1,0 +1,6 @@
+paths-ignore:
+  - bin/**
+
+query-filters:
+  - exclude:
+      id: go/path-injection

--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -1,0 +1,59 @@
+name: Analyze CodeQL
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.jpg"
+      - "**.png"
+      - "**.gif"
+      - "**.svg"
+      - "adr/**"
+      - "docs/**"
+      - "CODEOWNERS"
+  schedule:
+    - cron: "32 2 * * 5"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go", "javascript"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        env:
+          CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql.yaml
+
+      - name: Build
+        run: make build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "javascript"]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        with:
+          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-lula
+bin/
 compliance_report-*
 out/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Lula - The Kubernetes Compliance Engine
 
-lula is a tool written to bridge the gap between expected configuration required for compliance and **_actual_** configuration.
+[![Go version](https://img.shields.io/github/go-mod/go-version/defenseunicorns/lula?filename=go.mod)](https://go.dev/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/lula/badge)](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/lula)
+
+Lula is a tool written to bridge the gap between expected configuration required for compliance and **_actual_** configuration.
 
 Cloud Native Infrastructure, Platforms, and applications can establish OSCAL documents that live beside source-of-truth code bases. Providing an inheritance model for when a control that the technology can satisfy _IS_ satisfied in a live-environment.
 


### PR DESCRIPTION
This PR introduces two workflows, one for Code QL and another for OpenSSF's scorecard.

⚠️ As is, this is setup to use a scorecard read token named SCORECARD_READ_TOKEN (which is optional but gives more info). See more here: https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional

This also adds badges similar to the Zarf repo, but those could be removed if desired (Zarf also has release badges and other things on the top of its README.md as well)