### PR TITLE
feat: initial renovate setup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "extends": ["config:base"],
+  "ignorePaths": ["**/adr/**", "**/docs/**", "**/test/**"],
+  "timezone": "America/New_York",
+  "schedule": ["after 12pm and before 11am every weekday"],
+  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ],
+  "platformAutomerge": true,
+  "platformCommit": true,
+  "postUpdateOptions": ["gomodTidy"],
+  "commitBodyTable": true
+}


### PR DESCRIPTION
Initial renovate setup. 

Using Zarf and DUBBD as starting points. 

Will need to update overtime as the project continues to expand and dependencies change.

(Currently set to every weekday, if it becomes too noisy we can lower it)