### PR TITLE
Feat: Aggregate by control-id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/swaggest/jsonschema-go v0.3.64 // indirect
-	github.com/swaggest/refl v1.3.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/vladimirvivien/gexe v0.2.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/defenseunicorns/go-oscal v0.0.0-20231204225035-bc005d085d3b h1:nUYGGPO8QIyv7SbEq6HwvKnoZobKqj/yKTU5L9Qhh0E=
-github.com/defenseunicorns/go-oscal v0.0.0-20231204225035-bc005d085d3b/go.mod h1:WnHq9vtRwSyVpUKFlZW/BSRaZFGWRjzY3Z0pD4dQ32c=
 github.com/defenseunicorns/go-oscal v0.0.1 h1:FuzkOCNfExipUVGpuQYSrk1/jL04CfqWTZCii13Kt5I=
 github.com/defenseunicorns/go-oscal v0.0.1/go.mod h1:WnHq9vtRwSyVpUKFlZW/BSRaZFGWRjzY3Z0pD4dQ32c=
 github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0AKt0akg=
@@ -180,10 +178,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/swaggest/jsonschema-go v0.3.64 h1:HyB41fkA4XP0BZkqWfGap5i2JtRHQGXG/21dGDPbyLM=
-github.com/swaggest/jsonschema-go v0.3.64/go.mod h1:DYuKqdpms/edvywsX6p1zHXCZkdwB28wRaBdFCe3Duw=
-github.com/swaggest/refl v1.3.0 h1:PEUWIku+ZznYfsoyheF97ypSduvMApYyGkYF3nabS0I=
-github.com/swaggest/refl v1.3.0/go.mod h1:3Ujvbmh1pfSbDYjC6JGG7nMgPvpG0ehQL4iNonnLNbg=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/vladimirvivien/gexe v0.2.0 h1:nbdAQ6vbZ+ZNsolCgSVb9Fno60kzSuvtzVh6Ytqi/xY=

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -2,13 +2,11 @@ package oscal
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
 	"github.com/defenseunicorns/lula/src/config"
-	"github.com/defenseunicorns/lula/src/types"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,78 +24,21 @@ func NewAssessmentResults(data []byte) (oscalTypes.AssessmentResults, error) {
 	return assessmentResults, nil
 }
 
-func GenerateAssessmentResults(report *types.ReportObject) (oscalTypes.AssessmentResults, error) {
+func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observations []oscalTypes.Observation) (oscalTypes.AssessmentResults, error) {
 	var assessmentResults oscalTypes.AssessmentResults
 
 	// Single time used for all time related fields
 	rfc3339Time := time.Now().Format(time.RFC3339)
-
-	// Create placeholders for data required in objects
-	controlMap := make(map[string]bool)
 	controlList := make([]oscalTypes.SelectControlById, 0)
 	findings := make([]oscalTypes.Finding, 0)
-	observations := make([]oscalTypes.Observation, 0)
-
-	// Build the controlMap and Findings array
-	for _, component := range report.Components {
-		for _, controlImplementation := range component.ControlImplementations {
-			for _, implementedRequirement := range controlImplementation.ImplementedReqs {
-				tempObservations := make([]oscalTypes.Observation, 0)
-				relatedObservations := make([]oscalTypes.RelatedObservation, 0)
-				// For each result - there may be many observations
-				for _, result := range implementedRequirement.Results {
-					sharedUuid := uuid.NewUUID()
-					observation := oscalTypes.Observation{
-						Collected:   rfc3339Time,
-						Description: fmt.Sprintf("[TEST] %s - %s\n", implementedRequirement.ControlId, result.UUID),
-						Methods:     []string{"TEST"},
-						UUID:        sharedUuid,
-						RelevantEvidence: []oscalTypes.RelevantEvidence{
-							{
-								Description: fmt.Sprintf("Result: %s - Passing Resources: %s - Failing Resources %s\n", result.State, strconv.Itoa(result.Passing), strconv.Itoa(result.Failing)),
-							},
-						},
-					}
-
-					relatedObservation := oscalTypes.RelatedObservation{
-						ObservationUuid: sharedUuid,
-					}
-
-					relatedObservations = append(relatedObservations, relatedObservation)
-					tempObservations = append(tempObservations, observation)
-				}
-
-				if _, ok := controlMap[implementedRequirement.ControlId]; ok {
-					continue
-				} else {
-					controlMap[implementedRequirement.ControlId] = true
-				}
-				// TODO: Need to add in the control implementation UUID
-				finding := oscalTypes.Finding{
-					UUID:        uuid.NewUUID(),
-					Title:       fmt.Sprintf("Validation Result - Component:%s / Control Implementation: %s / Control:  %s", component.UUID, controlImplementation.UUID, implementedRequirement.ControlId),
-					Description: implementedRequirement.Description,
-					Target: oscalTypes.FindingTarget{
-						Status: oscalTypes.Status{
-							State: implementedRequirement.State,
-						},
-						TargetId: implementedRequirement.ControlId,
-						Type:     "objective-id",
-					},
-					RelatedObservations: relatedObservations,
-				}
-				findings = append(findings, finding)
-				observations = append(observations, tempObservations...)
-			}
-		}
-	}
 
 	// Convert control map to slice of SelectControlById
-	for controlId := range controlMap {
+	for controlId, finding := range findingMap {
 		control := oscalTypes.SelectControlById{
 			ControlId: controlId,
 		}
 		controlList = append(controlList, control)
+		findings = append(findings, finding)
 	}
 
 	// Always create a new UUID for the assessment results (for now)

--- a/src/test/e2e/api_validation_test.go
+++ b/src/test/e2e/api_validation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/defenseunicorns/lula/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/test/util"
-	"github.com/defenseunicorns/lula/src/types"
 	corev1 "k8s.io/api/core/v1"
 	// netv1 "k8s.io/api/networking/v1"
 	// "sigs.k8s.io/e2e-framework/klient/k8s"
@@ -49,21 +48,20 @@ func TestApiValidation(t *testing.T) {
 			return ctx
 		}).
 		Assess("Validate API response field", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-			oscalPath := []string{"./scenarios/api-field/oscal-component.yaml"}
+			oscalPath := "./scenarios/api-field/oscal-component.yaml"
 
-			results := types.ReportObject{
-				FilePaths: oscalPath,
-			}
-			err := validate.ValidateOnPaths(&results)
+			findingMap, _, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			result := results.Components[0].ControlImplementations[0].ImplementedReqs[0].Results[0]
-
-			if result.State != "satisfied" {
-				t.Fatal("State should be satisfied, but got :", result.State)
+			for _, finding := range findingMap {
+				state := finding.Target.Status.State
+				if state != "satisfied" {
+					t.Fatal("State should be satisfied, but got :", state)
+				}
 			}
+
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
@@ -123,21 +121,18 @@ func TestApiValidation(t *testing.T) {
 			return ctx
 		}).
 		Assess("Validate API response field", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-			oscalPath := []string{"./scenarios/api-field/oscal-component.yaml"}
+			oscalPath := "./scenarios/api-field/oscal-component.yaml"
 
-			results := types.ReportObject{
-				FilePaths: oscalPath,
-			}
-			err := validate.ValidateOnPaths(&results)
+			findingMap, _, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
-				t.Fatal("Validation error, result:", results)
+				t.Fatal(err)
 			}
 
-			// TODO: maybe this brings to light modifying the
-			result := results.Components[0].ControlImplementations[0].ImplementedReqs[0].Results[0]
-
-			if result.State != "not-satisfied" {
-				t.Fatal("State should be not-satisfied, but got :", result.State)
+			for _, finding := range findingMap {
+				state := finding.Target.Status.State
+				if state != "not-satisfied" {
+					t.Fatal("State should be not-satisfied, but got :", state)
+				}
 			}
 
 			return ctx

--- a/src/test/e2e/multi_resource_validation_test.go
+++ b/src/test/e2e/multi_resource_validation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/defenseunicorns/lula/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/test/util"
-	"github.com/defenseunicorns/lula/src/types"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
@@ -99,20 +98,18 @@ func TestMultiResourceValidation(t *testing.T) {
 			return ctx
 		}).
 		Assess("Validate Multi-Resource Collections", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-			oscalPath := []string{"./scenarios/multi-resource/oscal-component.yaml"}
+			oscalPath := "./scenarios/multi-resource/oscal-component.yaml"
 
-			results := types.ReportObject{
-				FilePaths: oscalPath,
-			}
-			err := validate.ValidateOnPaths(&results)
+			findingMap, _, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			result := results.Components[0].ControlImplementations[0].ImplementedReqs[0].Results[0]
-
-			if result.State != "satisfied" {
-				t.Fatal("State should be satisfied, but got :", result.State)
+			for _, finding := range findingMap {
+				state := finding.Target.Status.State
+				if state != "satisfied" {
+					t.Fatal("State should be satisfied, but got :", state)
+				}
 			}
 			return ctx
 		}).

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/defenseunicorns/lula/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/test/util"
-	"github.com/defenseunicorns/lula/src/types"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
@@ -32,21 +31,18 @@ func TestPodLabelValidation(t *testing.T) {
 			return context.WithValue(ctx, "test-pod-label", pod)
 		}).
 		Assess("Validate pod label", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-			oscalPath := []string{"./scenarios/pod-label/oscal-component.yaml"}
+			oscalPath := "./scenarios/pod-label/oscal-component.yaml"
 
-			results := types.ReportObject{
-				FilePaths: oscalPath,
-			}
-			err := validate.ValidateOnPaths(&results)
+			findingMap, _, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
-				t.Fatal("Validation error, result:", results)
+				t.Fatal(err)
 			}
 
-			// TODO: maybe this brings to light modifying the
-			result := results.Components[0].ControlImplementations[0].ImplementedReqs[0].Results[0]
-
-			if result.State != "satisfied" {
-				t.Fatal("State should be satisfied, but got :", result.State)
+			for _, finding := range findingMap {
+				state := finding.Target.Status.State
+				if state != "satisfied" {
+					t.Fatal("State should be satisfied, but got :", state)
+				}
 			}
 			return ctx
 		}).
@@ -74,20 +70,18 @@ func TestPodLabelValidation(t *testing.T) {
 			return context.WithValue(ctx, "test-pod-label", pod)
 		}).
 		Assess("Validate pod label", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-			oscalPath := []string{"./scenarios/pod-label/oscal-component.yaml"}
+			oscalPath := "./scenarios/pod-label/oscal-component.yaml"
 
-			results := types.ReportObject{
-				FilePaths: oscalPath,
-			}
-			err := validate.ValidateOnPaths(&results)
+			findingMap, _, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
-				t.Fatal("Validation error, result:", results)
+				t.Fatal(err)
 			}
 
-			result := results.Components[0].ControlImplementations[0].ImplementedReqs[0].Results[0]
-
-			if result.State != "not-satisfied" {
-				t.Fatal("State should be not-satisfied, but got :", result.State)
+			for _, finding := range findingMap {
+				state := finding.Target.Status.State
+				if state != "not-satisfied" {
+					t.Fatal("State should be not-satisfied, but got :", state)
+				}
 			}
 
 			return ctx

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -1,47 +1,10 @@
 package types
 
-// this is a temporary struct until a reporting model is selected
-type ComplianceReport struct {
-	UUID        string `json:"uuid" yaml:"uuid"`
-	ControlId   string `json:"control-id" yaml:"control-id"`
-	Description string `json:"description" yaml:"description"`
-	Result      string `json:"result" yaml:"result"`
-}
-
-// The ReportObject keeps track of all pertinent information as it relates to relational data IE UUID's
-// This will hopefully make transformation to the reporting model easier
-// or be replaced by an OSCAL native type
-type ReportObject struct {
-	FilePaths  []string    `json:"file-paths" yaml:"file-paths"`
-	UUID       string      `json:"uuid" yaml:"uuid"`
-	Components []Component `json:"components" yaml:"components"`
-	// Validations is a map[link UUID]Validation{}
-	Validations map[string]Validation `json:"validations" yaml:"validations"`
-}
-
 type Validation struct {
 	Title       string                 `json:"title" yaml:"title"`
 	Description map[string]interface{} `json:"description" yaml:"description"`
 	Evaluated   bool                   `json:"evaluated" yaml:"evaluated"`
 	Result      Result                 `json:"result" yaml:"result"`
-}
-
-type Component struct {
-	UUID                   string                  `json:"uuid" yaml:"uuid"`
-	ControlImplementations []ControlImplementation `json:"control-implementations" yaml:"control-implementations"`
-}
-
-type ControlImplementation struct {
-	UUID            string           `json:"uuid" yaml:"uuid"`
-	ImplementedReqs []ImplementedReq `json:"implemented-reqs" yaml:"implemented-reqs"`
-}
-
-type ImplementedReq struct {
-	UUID        string   `json:"uuid" yaml:"uuid"`
-	ControlId   string   `json:"control-id" yaml:"control-id"`
-	State       string   `json:"state" yaml:"state"`
-	Description string   `json:"description" yaml:"description"`
-	Results     []Result `json:"results" yaml:"results"`
 }
 
 // native type for conversion to targeted report format


### PR DESCRIPTION
Closes #161 

Removing temporary objects between component-definitions and the creation of assessment results. Now we generate the required findings and observations during validation directly and pass them to generate the assessment-results model around. 

This also unblocks #160 as it makes `control-id` unique - meaning we can compare two results and expect the state of a single finding to reflect all validations against that control-id. 