### PR TITLE
fix: 197 add input-file flag validation for validate command

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -41,6 +41,10 @@ var validateCmd = &cobra.Command{
 	Long:    "Lula Validation of an OSCAL component definition",
 	Example: validateHelp,
 	Run: func(cmd *cobra.Command, componentDefinitionPath []string) {
+		if opts.InputFile == "" {
+			message.Fatal(errors.New("flag input-file is not set"),
+				"Please specify an input file with the -f flag")
+		}
 		// Primary expected path for validation of OSCAL documents
 		findings, observations, err := ValidateOnPath(opts.InputFile)
 		if err != nil {


### PR DESCRIPTION
Closes #197 

## What changed

- Added validation of the flag `-f` for the `validate` command.

## Why do we need it

- UX improvement through early failure and clear error message.

## Questions

- Why it was decided to use `cobra` for such a simple CLI?
- Should behavioural tests be considered for the CLI flags? For context, automated tests for the `f` flag won't give much value now, but assuming long-term vision (based on the `cobra` framework), behavioural tests for all flags/commands might be beneficial.
