### PR TITLE
Fix: assessment result file provenance

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -318,9 +318,15 @@ func WriteReport(report oscalTypes.AssessmentResults, assessmentFilePath string)
 
 	var b bytes.Buffer
 
+	var sar = oscalTypes.OscalModels{
+		AssessmentResults: tempAssessment,
+	}
+
 	yamlEncoder := yaml.NewEncoder(&b)
 	yamlEncoder.SetIndent(2)
-	yamlEncoder.Encode(tempAssessment)
+	yamlEncoder.Encode(sar)
+
+	message.Infof("Writing Security Assessment Results to: %s", fileName)
 
 	err := os.WriteFile(fileName, b.Bytes(), 0644)
 	if err != nil {

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -13,15 +13,15 @@ import (
 const OSCAL_VERSION = "1.1.1"
 
 func NewAssessmentResults(data []byte) (oscalTypes.AssessmentResults, error) {
-	var assessmentResults oscalTypes.AssessmentResults
+	var oscalModels oscalTypes.OscalModels
 
-	err := yaml.Unmarshal(data, &assessmentResults)
+	err := yaml.Unmarshal(data, &oscalModels)
 	if err != nil {
 		fmt.Printf("Error marshalling yaml: %s\n", err.Error())
 		return oscalTypes.AssessmentResults{}, err
 	}
 
-	return assessmentResults, nil
+	return oscalModels.AssessmentResults, nil
 }
 
 func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observations []oscalTypes.Observation) (oscalTypes.AssessmentResults, error) {

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	validator "github.com/defenseunicorns/go-oscal/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
@@ -89,6 +90,12 @@ func TestPodLabelValidation(t *testing.T) {
 			if len(tempAssessment.Results) <= initialResultCount {
 				t.Fatal("Failed to append results to existing report")
 			}
+
+			validator, err := validator.ValidateCommand("sar-test.yaml")
+			if err != nil {
+				t.Fatal("File failed linting")
+			}
+			message.Infof("Successfully validated %s is valid OSCAL version %s %s\n", "sar-test.yaml", validator.GetSchemaVersion(), validator.GetModelType())
 
 			return ctx
 		}).

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/defenseunicorns/lula/src/cmd/validate"
+	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/defenseunicorns/lula/src/test/util"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +37,7 @@ func TestPodLabelValidation(t *testing.T) {
 			oscalPath := "./scenarios/pod-label/oscal-component.yaml"
 			message.NoProgress = true
 
-			findingMap, _, err := validate.ValidateOnPath(oscalPath)
+			findingMap, observations, err := validate.ValidateOnPath(oscalPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -46,6 +48,48 @@ func TestPodLabelValidation(t *testing.T) {
 					t.Fatal("State should be satisfied, but got :", state)
 				}
 			}
+
+			// Test report generation
+			report, err := oscal.GenerateAssessmentResults(findingMap, observations)
+			if err != nil {
+				t.Fatal("Failed generation of Assessment Results object with: ", err)
+			}
+
+			// Write report(s) to file
+			err = validate.WriteReport(report, "sar-test.yaml")
+			if err != nil {
+				t.Fatal("Failed to write report to file: ", err)
+			}
+
+			initialResultCount := len(report.Results)
+
+			//Perform the write operation again and read the file to ensure result was appended
+			report, err = oscal.GenerateAssessmentResults(findingMap, observations)
+			if err != nil {
+				t.Fatal("Failed generation of Assessment Results object with: ", err)
+			}
+
+			// Write report(s) to file
+			err = validate.WriteReport(report, "sar-test.yaml")
+			if err != nil {
+				t.Fatal("Failed to write report to file: ", err)
+			}
+
+			data, err := os.ReadFile("sar-test.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tempAssessment, err := oscal.NewAssessmentResults(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// The number of results in the file should be more than initially
+			if len(tempAssessment.Results) <= initialResultCount {
+				t.Fatal("Failed to append results to existing report")
+			}
+
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {


### PR DESCRIPTION
Closes #206 

Assessment results file would not pass linting as it did not contain the top level "assessment-results" key. This adds the fix and extends a test to include checking for proper append to file AND linting the output to ensure our reports are valid OSCAL.