### PR TITLE
fix: add detection/error for inability to connect to cluster

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -48,7 +48,7 @@ var validateCmd = &cobra.Command{
 		// Primary expected path for validation of OSCAL documents
 		findings, observations, err := ValidateOnPath(opts.InputFile)
 		if err != nil {
-			message.Fatalf(err, "Validation error")
+			message.Fatalf(err, "Validation error: %s", err)
 		}
 
 		report, err := oscal.GenerateAssessmentResults(findings, observations)

--- a/src/pkg/common/kubernetes/resource.go
+++ b/src/pkg/common/kubernetes/resource.go
@@ -65,7 +65,10 @@ func GetResourcesDynamically(ctx context.Context,
 	group string, version string, resource string, namespace string) (
 	[]unstructured.Unstructured, error) {
 
-	config := ctrl.GetConfigOrDie()
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Error with connection to the Cluster")
+	}
 	dynamic := dynamic.NewForConfigOrDie(config)
 
 	resourceId := schema.GroupVersionResource{
@@ -85,7 +88,10 @@ func GetResourcesDynamically(ctx context.Context,
 }
 
 func getGroupVersionResource(kind string) (gvr *schema.GroupVersionResource, err error) {
-	config := ctrl.GetConfigOrDie()
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Error with connection to the Cluster")
+	}
 	name := strings.Split(kind, "/")[0]
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)


### PR DESCRIPTION
Closes #210 

Creates an error which halts execution. Need to investigate the intended UX of continuing to check other validations or exiting here entirely (as is the case now).

Nonetheless, getting this error to the surface is important for early adopters.