### PR TITLE
Testing reusable modules and repeatable Rego generation

### DIFF
--- a/src/cmd/tools/rego.go
+++ b/src/cmd/tools/rego.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/defenseunicorns/lula/src/config"
+	"github.com/defenseunicorns/lula/src/pkg/message"
+	"github.com/spf13/cobra"
+)
+
+var regoHelp = `
+To create a new template for Rego Validation:
+	lula tools regogen
+
+To create a template given some resource kind:
+	lula tools regogen Deployment
+`
+
+var regoTemplate = `
+package validate
+import data.common
+
+result := get_allowances(input.{{ . | lower }}s)
+
+get_allowances(resources) = result {
+  valid := [name | resource := resources[_]; allowed(resource); name := common.print_resource(resource)]
+  invalid := [name | resource := resources[_]; not allowed(resource); name := common.print_resource(resource)]
+  result := {"passed": valid, "failed": invalid, "validate": count(invalid) == 0}
+}
+
+allowed(resource) {
+  resource.kind == "{{ . }}"
+  allowed_{{ . | lower }}(resource)
+}
+
+allowed_{{ . | lower }}({{ . | lower }}) {
+  # ** Change this **
+  # Logic for allowed {{ . }} instance
+  # example: {{ . | lower }}.metadata.namespace != "default"
+}
+
+allowed_{{ . | lower }}({{ . | lower }}) {
+  # Exempted {{ . }} instances by "<namespace>/<name>", regex supported
+  exempt := {} # example: {"istio-system/.*"} ** Change this **
+  common.exempted(exempt, {{ . | lower }})
+}
+`
+
+func init() {
+	// Kubectl stub command.
+	uuidCmd := &cobra.Command{
+		Use:   "regogen",
+		Short: "Generate a Rego Template for Validation",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			config.SkipLogFile = true
+		},
+		Long:    "Generate a Rego Template for the Lula Validation backmatter in an OSCAL document",
+		Example: regoHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			funcMap := template.FuncMap{
+				"lower": strings.ToLower,
+			}
+			tmpl, err := template.New("rego").Funcs(funcMap).Parse(regoTemplate)
+			if err != nil {
+				panic(err)
+			}
+
+			if len(args) == 0 {
+				err = tmpl.Execute(os.Stdout, "Resource")
+				if err != nil {
+					panic(err)
+				}
+			} else if len(args) == 1 {
+				err = tmpl.Execute(os.Stdout, args[0])
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				message.Fatal(fmt.Errorf("Too many arguments"), "Too many arguments")
+			}
+		},
+	}
+
+	toolsCmd.AddCommand(uuidCmd)
+}

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -3,7 +3,7 @@ package oscal
 import (
 	"fmt"
 
-	"github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
+	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
 	"github.com/defenseunicorns/lula/src/types"
 	"gopkg.in/yaml.v3"
 )
@@ -23,11 +23,11 @@ func NewOscalComponentDefinition(data []byte) (oscalTypes.ComponentDefinition, e
 }
 
 // Map an array of resources to a map of UUID to validation object
-func BackMatterToMap(backMatter oscalTypes.BackMatter) map[string]types.Validation {
+func BackMatterToMap(backMatter oscalTypes.BackMatter, resourceTitle string) map[string]types.Validation {
 	resourceMap := make(map[string]types.Validation)
 
 	for _, resource := range backMatter.Resources {
-		if resource.Title == "Lula Validation" {
+		if resource.Title == resourceTitle {
 			var lulaSelector map[string]interface{}
 
 			err := yaml.Unmarshal([]byte(resource.Description), &lulaSelector)

--- a/src/pkg/providers/opa/opa.go
+++ b/src/pkg/providers/opa/opa.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"regexp"
 
 	kube "github.com/defenseunicorns/lula/src/pkg/common/kubernetes"
 	"github.com/defenseunicorns/lula/src/types"
@@ -15,11 +16,13 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	rego_types "github.com/open-policy-agent/opa/types"
 )
 
 // TODO: What is the new version of the information we are displaying on the command line?
 
-func Validate(ctx context.Context, domain string, data map[string]interface{}) (types.Result, error) {
+func Validate(ctx context.Context, domain string, data map[string]interface{}, opaCommon map[string]types.Validation) (types.Result, error) {
+
 	if domain == "kubernetes" {
 		var payload types.Payload
 		err := mapstructure.Decode(data, &payload)
@@ -38,7 +41,7 @@ func Validate(ctx context.Context, domain string, data map[string]interface{}) (
 		}
 
 		// TODO: Add logging optionality for understanding what resources are actually being validated
-		results, err := GetValidatedAssets(ctx, payload.Rego, collection)
+		results, err := GetValidatedAssets(ctx, payload.Rego, collection, opaCommon)
 		if err != nil {
 			return types.Result{}, err
 		}
@@ -92,7 +95,7 @@ func Validate(ctx context.Context, domain string, data map[string]interface{}) (
 			}
 		}
 
-		results, err := GetValidatedAssets(ctx, payload.Rego, collection)
+		results, err := GetValidatedAssets(ctx, payload.Rego, collection, opaCommon)
 		if err != nil {
 			return types.Result{}, err
 		}
@@ -103,8 +106,14 @@ func Validate(ctx context.Context, domain string, data map[string]interface{}) (
 	return types.Result{}, fmt.Errorf("domain %s is not supported", domain)
 }
 
+type ResultData struct {
+	Failed   []string `json:"failed"`
+	Passed   []string `json:"passed"`
+	Validate bool     `json:"validate"`
+}
+
 // GetValidatedAssets performs the validation of the dataset against the given rego policy
-func GetValidatedAssets(ctx context.Context, regoPolicy string, dataset map[string]interface{}) (types.Result, error) {
+func GetValidatedAssets(ctx context.Context, regoPolicy string, dataset map[string]interface{}, opaCommon map[string]types.Validation) (types.Result, error) {
 	var matchResult types.Result
 
 	if len(dataset) == 0 {
@@ -113,9 +122,19 @@ func GetValidatedAssets(ctx context.Context, regoPolicy string, dataset map[stri
 		return matchResult, nil
 	}
 
-	compiler, err := ast.CompileModules(map[string]string{
-		"validate.rego": regoPolicy,
-	})
+	// Add modules
+	modules := make(map[string]string, 0)
+	modules["validate.rego"] = regoPolicy
+	for _, module := range opaCommon {
+		var payload types.Payload
+		err := mapstructure.Decode(module.Description["payload"], &payload)
+		if err != nil {
+			return types.Result{}, err
+		}
+		modules[payload.Resources[0].Name+".rego"] = payload.Rego
+	}
+
+	compiler, err := ast.CompileModules(modules)
 	if err != nil {
 		log.Fatal(err)
 		return matchResult, fmt.Errorf("failed to compile rego policy: %w", err)
@@ -145,15 +164,82 @@ func GetValidatedAssets(ctx context.Context, regoPolicy string, dataset map[stri
 			if err != nil {
 				return matchResult, fmt.Errorf("failed to unmarshal expression: %w", err)
 			}
+
+			// resultBytes, err := json.Marshal(expressionMap["result"])
+			// if err != nil {
+			// 	return matchResult, fmt.Errorf("failed to marshal expression: %w", err)
+			// }
+
+			// var resultMap map[string]interface{}
+			// err = json.Unmarshal(resultBytes, &resultMap)
+			// if err != nil {
+			// 	return matchResult, fmt.Errorf("failed to unmarshal expression: %w", err)
+			// }
+
+			// fmt.Println(string(resultBytes))
+
+			var buf bytes.Buffer
+			if err := json.NewEncoder(&buf).Encode(expressionMap["result"]); err != nil {
+				return matchResult, fmt.Errorf("unable to encode: %w", err)
+			}
+
+			var data ResultData
+			if err := json.NewDecoder(&buf).Decode(&data); err != nil {
+				return matchResult, fmt.Errorf("unable to decode: %w", err)
+			}
+
 			// TODO: add logging optionality here for developer experience
-			if matched, ok := expressionMap["validate"]; ok && matched.(bool) {
+			if data.Validate {
 				// TODO: Is there a way to determine how many resources failed?
-				matchResult.Passing += 1
+				// matchResult.Passing += 1
+				matchResult.Passing = len(data.Passed)
+				matchResult.PassingList = data.Passed
 			} else {
-				matchResult.Failing += 1
+				// matchResult.Failing += 1
+				matchResult.Failing = len(data.Failed)
+				matchResult.FailingList = data.Failed
 			}
 		}
 	}
 
 	return matchResult, nil
+}
+
+// Messing with running functions in go... but not currently implemented
+// RegoGetExemptions returns the rego function to get the exemptions for a resource
+func RegoGetExemptions() func(*rego.Rego) {
+	return rego.Function3(
+		&rego.Function{
+			Name: "get_exemptions",
+			Decl: rego_types.NewFunction(rego_types.Args(rego_types.A, rego_types.S, rego_types.S), rego_types.B),
+		},
+		func(bctx rego.BuiltinContext, exemptions, namespace, name *ast.Term) (*ast.Term, error) {
+			exempts := []string{}
+			if err := json.Unmarshal([]byte(exemptions.Value.String()), &exempts); err != nil {
+				return nil, fmt.Errorf("unmarshal rego exemptions data: %v", err)
+			}
+			if matchesRegexInSlice(namespace.Value.String()+"/"+name.Value.String(), exempts) {
+				return ast.BooleanTerm(true), nil
+			} else {
+				return ast.BooleanTerm(false), nil
+			}
+		},
+	)
+}
+
+// matchesRegexInSlice checks if a value matches any regex pattern in the provided slice
+func matchesRegexInSlice(value string, slice []string) bool {
+	for _, item := range slice {
+		// Compile the pattern
+		pattern, err := regexp.Compile(item)
+		if err != nil {
+			fmt.Printf("Invalid regex pattern \"%s\": %v\n", item, err)
+			continue // Skip invalid patterns
+		}
+		// Check if the value matches the pattern
+		if pattern.MatchString(value) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -9,12 +9,14 @@ type Validation struct {
 
 // native type for conversion to targeted report format
 type Result struct {
-	UUID        string `json:"uuid" yaml:"uuid"`
-	ControlId   string `json:"control-id" yaml:"control-id"`
-	Description string `json:"description" yaml:"description"`
-	Passing     int    `json:"passing" yaml:"passing"`
-	Failing     int    `json:"failing" yaml:"failing"`
-	State       string `json:"state" yaml:"state"`
+	UUID        string   `json:"uuid" yaml:"uuid"`
+	ControlId   string   `json:"control-id" yaml:"control-id"`
+	Description string   `json:"description" yaml:"description"`
+	Passing     int      `json:"passing" yaml:"passing"`
+	PassingList []string `json:"passing-list" yaml:"passing-list"`
+	Failing     int      `json:"failing" yaml:"failing"`
+	FailingList []string `json:"failing-list" yaml:"failing-list"`
+	State       string   `json:"state" yaml:"state"`
 }
 
 // Current placeholder for all requisite data in the payload


### PR DESCRIPTION
The intent of this PR was to look at trying to DRY out the rego code a little more, add some reusable components, and just keep an eye toward making the lives easier of people that are going to find themselves writing this stuff. There's a couple things contained:
1) `lula tools regogen` creates a rego template, optionally passing it a resource kind will template with that structure (e.g., `lula tools regogen Deployment` - The hope was to create a kind of framework that ensures outputs are common and certain reusable functionality (like exemptions) can be re-used. This skeleton also hopefully indicates a few places for a user to change to meet logic ("** Change this **"). Obviously we have a really small sample set right now so this template may not cover all cases and perhaps there's different flavor templates for different types of controls.
2) Shared modules in the code - as an addendum to the above statement, the reusable scripts have to actually be accessible. I thought about putting it in our codebase, but it seems like transparency is key so ended up adding a type of backmatter to hold those modules. This ended up touching quite a bit of code but really just a proof of concept for what it could look like. This part was tested out with `Istio-common.yaml` which is on the `istio-common` branch of compliance-artifacts.