### PR TITLE
#278. Upgrade go-oscal package. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ compliance_report-*
 out/
 assessment-results-*.yaml
 .idea
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "go.alternateTools": {
-        "go.gopath": "/home/tripplesixactual/.gvm/pkgsets/go1.21.3/global",
-        "go.goroot": "/home/tripplesixactual/.gvm/gos/go1.21.3",
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go.alternateTools": {
+        "go.gopath": "/home/tripplesixactual/.gvm/pkgsets/go1.21.3/global",
+        "go.goroot": "/home/tripplesixactual/.gvm/gos/go1.21.3",
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/defenseunicorns/lula
 go 1.22.0
 
 require (
-	github.com/defenseunicorns/go-oscal v0.1.0
+	github.com/defenseunicorns/go-oscal v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-policy-agent/opa v0.61.0
 	github.com/pterm/pterm v0.12.79
@@ -95,6 +95,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/swaggest/jsonschema-go v0.3.66 // indirect
+	github.com/swaggest/refl v1.3.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/vladimirvivien/gexe v0.2.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX
 github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
 github.com/defenseunicorns/go-oscal v0.1.0 h1:X3EOjEyQ5XvdD6xjIyhrtBhhg/bPgYdEXRjXjK6sd4s=
 github.com/defenseunicorns/go-oscal v0.1.0/go.mod h1:y1esWKT2qg77jVwGHYjOy0mcjPQinujj3UAVbnq2xxI=
+github.com/defenseunicorns/go-oscal v0.2.0 h1:hyRMUoQT2RFk/VIxz19yZKngobjdIuI+si6+k7+OX/M=
+github.com/defenseunicorns/go-oscal v0.2.0/go.mod h1:4JXNIFmWK1VBHpmXicW/g65MizUEHKUexy3Lb2lH2/I=
 github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0AKt0akg=
 github.com/dgraph-io/badger/v3 v3.2103.5/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
@@ -306,6 +308,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/swaggest/jsonschema-go v0.3.66 h1:4c5d7NRRqPLTswsbaypKqcMe3Z+CYHE3/lGsPIByp8o=
+github.com/swaggest/jsonschema-go v0.3.66/go.mod h1:7N43/CwdaWgPUDfYV70K7Qm79tRqe/al7gLSt9YeGIE=
+github.com/swaggest/refl v1.3.0 h1:PEUWIku+ZznYfsoyheF97ypSduvMApYyGkYF3nabS0I=
+github.com/swaggest/refl v1.3.0/go.mod h1:3Ujvbmh1pfSbDYjC6JGG7nMgPvpG0ehQL4iNonnLNbg=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/vladimirvivien/gexe v0.2.0 h1:nbdAQ6vbZ+ZNsolCgSVb9Fno60kzSuvtzVh6Ytqi/xY=

--- a/src/cmd/evaluate/evaluate.go
+++ b/src/cmd/evaluate/evaluate.go
@@ -3,7 +3,7 @@ package evaluate
 import (
 	"fmt"
 
-	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
@@ -49,7 +49,7 @@ func EvaluateCommand() *cobra.Command {
 
 func EvaluateAssessmentResults(files []string) error {
 	var status bool
-	var findings map[string][]oscalTypes.Finding
+	var findings map[string][]oscalTypes_1_1_2.Finding
 	// Read in files - establish the results to
 	if len(files) == 0 {
 		// TODO: Determine if we will handle a default location/name for assessment files
@@ -120,12 +120,12 @@ func EvaluateAssessmentResults(files []string) error {
 	}
 }
 
-func EvaluateResults(thresholdResult oscalTypes.Result, newResult oscalTypes.Result) (bool, map[string][]oscalTypes.Finding, error) {
+func EvaluateResults(thresholdResult oscalTypes_1_1_2.Result, newResult oscalTypes_1_1_2.Result) (bool, map[string][]oscalTypes_1_1_2.Finding, error) {
 	spinner := message.NewProgressSpinner("Evaluating Assessment Results %s against %s", newResult.UUID, thresholdResult.UUID)
 	defer spinner.Stop()
 
 	// Store unique findings for review here
-	findings := make(map[string][]oscalTypes.Finding, 0)
+	findings := make(map[string][]oscalTypes_1_1_2.Finding, 0)
 	result := true
 
 	findingMapThreshold := oscal.GenerateFindingsMap(thresholdResult.Findings)

--- a/src/cmd/evaluate/evaluate_test.go
+++ b/src/cmd/evaluate/evaluate_test.go
@@ -3,7 +3,7 @@ package evaluate
 import (
 	"testing"
 
-	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 )
 
@@ -11,12 +11,12 @@ import (
 func TestEvaluateResultsPassing(t *testing.T) {
 	message.NoProgress = true
 
-	mockThresholdResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockThresholdResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
@@ -24,12 +24,12 @@ func TestEvaluateResultsPassing(t *testing.T) {
 		},
 	}
 
-	mockEvaluationResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockEvaluationResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
@@ -51,12 +51,12 @@ func TestEvaluateResultsPassing(t *testing.T) {
 
 func TestEvaluateResultsFailed(t *testing.T) {
 	message.NoProgress = true
-	mockThresholdResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockThresholdResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
@@ -64,12 +64,12 @@ func TestEvaluateResultsFailed(t *testing.T) {
 		},
 	}
 
-	mockEvaluationResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockEvaluationResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "not-satisfied",
 					},
 				},
@@ -95,12 +95,12 @@ func TestEvaluateResultsFailed(t *testing.T) {
 
 func TestEvaluateResultsNewFindings(t *testing.T) {
 	message.NoProgress = true
-	mockThresholdResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockThresholdResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
@@ -108,28 +108,28 @@ func TestEvaluateResultsNewFindings(t *testing.T) {
 		},
 	}
 	// Adding two new findings
-	mockEvaluationResult := oscalTypes.Result{
-		Findings: []oscalTypes.Finding{
+	mockEvaluationResult := oscalTypes_1_1_2.Result{
+		Findings: []oscalTypes_1_1_2.Finding{
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-1",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
 			},
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-2",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "satisfied",
 					},
 				},
 			},
 			{
-				Target: oscalTypes.FindingTarget{
+				Target: oscalTypes_1_1_2.FindingTarget{
 					TargetId: "ID-3",
-					Status: oscalTypes.Status{
+					Status: oscalTypes_1_1_2.ObjectiveStatus{
 						State: "not-satisfied",
 					},
 				},

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -5,36 +5,36 @@ import (
 	"time"
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
-	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/config"
 	"gopkg.in/yaml.v3"
 )
 
-const OSCAL_VERSION = "1.1.1"
+const OSCAL_VERSION = "1.1.2"
 
-func NewAssessmentResults(data []byte) (oscalTypes.AssessmentResults, error) {
-	var oscalModels oscalTypes.OscalModels
+func NewAssessmentResults(data []byte) (oscalTypes_1_1_2.AssessmentResults, error) {
+	var oscalModels oscalTypes_1_1_2.OscalModels
 
 	err := yaml.Unmarshal(data, &oscalModels)
 	if err != nil {
 		fmt.Printf("Error marshalling yaml: %s\n", err.Error())
-		return oscalTypes.AssessmentResults{}, err
+		return oscalTypes_1_1_2.AssessmentResults{}, err
 	}
 
 	return oscalModels.AssessmentResults, nil
 }
 
-func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observations []oscalTypes.Observation) (oscalTypes.AssessmentResults, error) {
-	var assessmentResults oscalTypes.AssessmentResults
+func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, observations []oscalTypes_1_1_2.Observation) (oscalTypes_1_1_2.AssessmentResults, error) {
+	var assessmentResults oscalTypes_1_1_2.AssessmentResults
 
 	// Single time used for all time related fields
-	rfc3339Time := time.Now().Format(time.RFC3339)
-	controlList := make([]oscalTypes.SelectControlById, 0)
-	findings := make([]oscalTypes.Finding, 0)
+	rfc3339Time := time.Now()
+	controlList := make([]oscalTypes_1_1_2.AssessedControlsSelectControlById, 0)
+	findings := make([]oscalTypes_1_1_2.Finding, 0)
 
 	// Convert control map to slice of SelectControlById
 	for controlId, finding := range findingMap {
-		control := oscalTypes.SelectControlById{
+		control := oscalTypes_1_1_2.AssessedControlsSelectControlById{
 			ControlId: controlId,
 		}
 		controlList = append(controlList, control)
@@ -46,7 +46,7 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observa
 
 	// Create metadata object with requires fields and a few extras
 	// Where do we establish what `version` should be?
-	assessmentResults.Metadata = oscalTypes.Metadata{
+	assessmentResults.Metadata = oscalTypes_1_1_2.Metadata{
 		Title:        "[System Name] Security Assessment Results (SAR)",
 		Version:      "0.0.1",
 		OscalVersion: OSCAL_VERSION,
@@ -56,16 +56,16 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observa
 	}
 
 	// Create results object
-	assessmentResults.Results = []oscalTypes.Result{
+	assessmentResults.Results = []oscalTypes_1_1_2.Result{
 		{
 			UUID:        uuid.NewUUID(),
 			Title:       "Lula Validation Result",
 			Start:       rfc3339Time,
 			Description: "Assessment results for performing Validations with Lula version " + config.CLIVersion,
-			ReviewedControls: oscalTypes.ReviewedControls{
+			ReviewedControls: oscalTypes_1_1_2.ReviewedControls{
 				Description: "Controls validated",
 				Remarks:     "Validation performed may indicate full or partial satisfaction",
-				ControlSelections: []oscalTypes.AssessedControls{
+				ControlSelections: []oscalTypes_1_1_2.AssessedControls{
 					{
 						Description:     "Controls Assessed by Lula",
 						IncludeControls: controlList,
@@ -80,8 +80,8 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes.Finding, observa
 	return assessmentResults, nil
 }
 
-func GenerateFindingsMap(findings []oscalTypes.Finding) map[string]oscalTypes.Finding {
-	findingsMap := make(map[string]oscalTypes.Finding)
+func GenerateFindingsMap(findings []oscalTypes_1_1_2.Finding) map[string]oscalTypes_1_1_2.Finding {
+	findingsMap := make(map[string]oscalTypes_1_1_2.Finding)
 	for _, finding := range findings {
 		findingsMap[finding.Target.TargetId] = finding
 	}

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -3,15 +3,15 @@ package oscal
 import (
 	"fmt"
 
-	"github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-1"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/types"
 	"gopkg.in/yaml.v3"
 )
 
 // NewOscalComponentDefinition consumes a byte array and returns a new single OscalComponentDefinitionModel object
 // Standard use is to read a file from the filesystem and pass the []byte to this function
-func NewOscalComponentDefinition(data []byte) (oscalTypes.ComponentDefinition, error) {
-	var oscalModels oscalTypes.OscalModels
+func NewOscalComponentDefinition(data []byte) (oscalTypes_1_1_2.ComponentDefinition, error) {
+	var oscalModels oscalTypes_1_1_2.OscalModels
 
 	err := yaml.Unmarshal(data, &oscalModels)
 	if err != nil {
@@ -23,7 +23,7 @@ func NewOscalComponentDefinition(data []byte) (oscalTypes.ComponentDefinition, e
 }
 
 // Map an array of resources to a map of UUID to validation object
-func BackMatterToMap(backMatter oscalTypes.BackMatter) map[string]types.Validation {
+func BackMatterToMap(backMatter oscalTypes_1_1_2.BackMatter) map[string]types.Validation {
 	resourceMap := make(map[string]types.Validation)
 
 	for _, resource := range backMatter.Resources {

--- a/src/test/e2e/sar-test.yaml
+++ b/src/test/e2e/sar-test.yaml
@@ -1,0 +1,76 @@
+assessment-results:
+  import-ap:
+    href: ""
+  metadata:
+    last-modified: 2024-02-29T11:24:24.301624885-08:00
+    oscal-version: 1.1.2
+    published: 2024-02-29T11:24:24.301624885-08:00
+    remarks: Assessment Results generated from Lula
+    title: '[System Name] Security Assessment Results (SAR)'
+    version: 0.0.1
+  results:
+    - description: Assessment results for performing Validations with Lula version unset
+      findings:
+        - description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum  dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          related-observations:
+            - observation-uuid: ea389817-a522-4efc-9b9b-a080cb520e14
+          target:
+            status:
+              state: satisfied
+            target-id: ID-1
+            type: objective-id
+          title: 'Validation Result - Component:A9D5204C-7E5B-4C43-BD49-34DF759B9F04 / Control Implementation: A584FEDC-8CEA-4B0C-9F07-85C2C4AE751A / Control:  ID-1'
+          uuid: ecf5c7b3-7de6-4ee5-86db-fc83bcbd238c
+      observations:
+        - collected: 2024-02-29T11:24:24.294432098-08:00
+          description: |
+            [TEST] ID-1 - 88AB3470-B96B-4D7C-BC36-02BF9563C46C
+          methods:
+            - TEST
+          relevant-evidence:
+            - description: |
+                Result: satisfied - Passing Resources: 1 - Failing Resources 0
+          uuid: ea389817-a522-4efc-9b9b-a080cb520e14
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ID-1
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2024-02-29T11:24:24.302709841-08:00
+      title: Lula Validation Result
+      uuid: 22ae3869-d09f-4c02-9116-7640415ba832
+    - description: Assessment results for performing Validations with Lula version unset
+      findings:
+        - description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum  dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          related-observations:
+            - observation-uuid: ea389817-a522-4efc-9b9b-a080cb520e14
+          target:
+            status:
+              state: satisfied
+            target-id: ID-1
+            type: objective-id
+          title: 'Validation Result - Component:A9D5204C-7E5B-4C43-BD49-34DF759B9F04 / Control Implementation: A584FEDC-8CEA-4B0C-9F07-85C2C4AE751A / Control:  ID-1'
+          uuid: ecf5c7b3-7de6-4ee5-86db-fc83bcbd238c
+      observations:
+        - collected: 2024-02-29T11:24:24.294432098-08:00
+          description: |
+            [TEST] ID-1 - 88AB3470-B96B-4D7C-BC36-02BF9563C46C
+          methods:
+            - TEST
+          relevant-evidence:
+            - description: |
+                Result: satisfied - Passing Resources: 1 - Failing Resources 0
+          uuid: ea389817-a522-4efc-9b9b-a080cb520e14
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ID-1
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2024-02-29T11:24:24.301624885-08:00
+      title: Lula Validation Result
+      uuid: 35a6dfbd-23de-49a3-a920-7a8a970c4928
+  uuid: 3df8ed53-090c-45b4-9bf1-5e8dd895d1bc


### PR DESCRIPTION
Upon release of go-oscal v0.2.0 we will want to update Lula.

## Purpose
Types have changed and updating the output of Lula to produce oscal version `1.1.2` documents as aligned with the latest release of OSCAL is our goal. 

## Objectives
- Any modifications to data types used (Should only be `component-definition` and `assessment-results` at this time)
- Update the `OSCAL_VERSION` constant for `assessment-results`
- Update component-definitions in the e2e tests to `1.1.2` 