### PR TITLE
Lula Version Property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,14 @@ GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_SHA    = $(shell git rev-parse --short HEAD)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 CLI_VERSION ?= $(if $(shell git describe --tags),$(shell git describe --tags),"UnknownVersion")
+NON_PRERELEASE_VERSION ?= $(if $(shell git describe --tags --abbrev=0),$(shell git describe --tags --abbrev=0),"UnknownVersion")
 
 # Go CLI options
 PKG         := ./...
 TAGS        :=
 TESTS       := .
 TESTFLAGS   := -race -v
-LDFLAGS     := -w -s -X 'github.com/defenseunicorns/lula/src/config.CLIVersion=$(GIT_SHA)'
+LDFLAGS     := -w -s -X 'github.com/defenseunicorns/lula/src/config.CLIVersion=$(NON_PRERELEASE_VERSION)'
 GOFLAGS     :=
 CGO_ENABLED ?= 0
 

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,13 @@ GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_SHA    = $(shell git rev-parse --short HEAD)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 CLI_VERSION ?= $(if $(shell git describe --tags),$(shell git describe --tags),"UnknownVersion")
-NON_PRERELEASE_VERSION ?= $(if $(shell git describe --tags --abbrev=0),$(shell git describe --tags --abbrev=0),"UnknownVersion")
 
 # Go CLI options
 PKG         := ./...
 TAGS        :=
 TESTS       := .
 TESTFLAGS   := -race -v
-LDFLAGS     := -w -s -X 'github.com/defenseunicorns/lula/src/config.CLIVersion=$(NON_PRERELEASE_VERSION)'
+LDFLAGS     := -w -s -X 'github.com/defenseunicorns/lula/src/config.CLIVersion=$(CLI_VERSION)'
 GOFLAGS     :=
 CGO_ENABLED ?= 0
 

--- a/docs/version-specification.md
+++ b/docs/version-specification.md
@@ -2,31 +2,32 @@
 In cases where a specific version of Lula is desired, either for typing constraints or desired functionality, a `lulaVersion` property is recognized in the `description` (component-definition.back-matter.resources[_]):
 ```yaml
 - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-    title: Lula Validation
-    remarks: >-
+  title: Lula Validation
+  remarks: >-
     No outputs in payload
-    description: |
+  description: |
     lulaVersion: ">=0.0.2"
     target:
-        provider: opa
-        domain: kubernetes
-        payload:
+      provider: opa
+      domain: kubernetes
+      payload:
         resources:
-        - name: hc
-            resourceRule:
-            Name: helm-controller
-            Group: apps
+        - name: podsvt
+          resourceRule:
+            Group:
             Version: v1
-            Resource: deployments
-            Namespaces: [flux-system]
-        rego: |
-            package validate
+            Resource: pods
+            Namespaces: [validation-test]
+        rego: |                                   
+          package validate
 
-            import future.keywords.every
+          import future.keywords.every
 
-            validate {
-            true
+          validate { 
+            every pod in input.podsvt {
+              podLabel == "bar"
             }
+          }
 ```
 
 If included, the `lulaVersion` must be a string and should indicate the version constraints desired, if any. Our implementation uses Hashicorp's [go-version](https://pkg.go.dev/github.com/hashicorp/go-version) library, and constraints should follow their [conventions](https://developer.hashicorp.com/terraform/language/expressions/version-constraints). 

--- a/docs/version-specification.md
+++ b/docs/version-specification.md
@@ -1,0 +1,34 @@
+# Version Specification
+In cases where a specific version of Lula is desired, either for typing constraints or desired functionality, a `lulaVersion` property is recognized in the `description` (component-definition.back-matter.resources[_]):
+```yaml
+- uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
+    title: Lula Validation
+    remarks: >-
+    No outputs in payload
+    description: |
+    lulaVersion: ">=0.0.2"
+    target:
+        provider: opa
+        domain: kubernetes
+        payload:
+        resources:
+        - name: hc
+            resourceRule:
+            Name: helm-controller
+            Group: apps
+            Version: v1
+            Resource: deployments
+            Namespaces: [flux-system]
+        rego: |
+            package validate
+
+            import future.keywords.every
+
+            validate {
+            true
+            }
+```
+
+If included, the `lulaVersion` must be a string and should indicate the version constraints desired, if any. Our implementation uses Hashicorp's [go-version](https://pkg.go.dev/github.com/hashicorp/go-version) library, and constraints should follow their [conventions](https://developer.hashicorp.com/terraform/language/expressions/version-constraints). 
+
+If an invalid string is passed or the current Lula version does not meet version constraints, the implementation will automatically be marked "not-satisfied" and a remark will be created in the Assessment Report detailing the rationale.

--- a/docs/version-specification.md
+++ b/docs/version-specification.md
@@ -1,12 +1,12 @@
 # Version Specification
-In cases where a specific version of Lula is desired, either for typing constraints or desired functionality, a `lulaVersion` property is recognized in the `description` (component-definition.back-matter.resources[_]):
+In cases where a specific version of Lula is desired, either for typing constraints or desired functionality, a `lula-version` property is recognized in the `description` (component-definition.back-matter.resources[_]):
 ```yaml
 - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
   title: Lula Validation
   remarks: >-
     No outputs in payload
   description: |
-    lulaVersion: ">=0.0.2"
+    lula-version: ">=0.0.2"
     target:
       provider: opa
       domain: kubernetes
@@ -30,6 +30,6 @@ In cases where a specific version of Lula is desired, either for typing constrai
           }
 ```
 
-If included, the `lulaVersion` must be a string and should indicate the version constraints desired, if any. Our implementation uses Hashicorp's [go-version](https://pkg.go.dev/github.com/hashicorp/go-version) library, and constraints should follow their [conventions](https://developer.hashicorp.com/terraform/language/expressions/version-constraints). 
+If included, the `lula-version` must be a string and should indicate the version constraints desired, if any. Our implementation uses Hashicorp's [go-version](https://pkg.go.dev/github.com/hashicorp/go-version) library, and constraints should follow their [conventions](https://developer.hashicorp.com/terraform/language/expressions/version-constraints). 
 
 If an invalid string is passed or the current Lula version does not meet version constraints, the implementation will automatically be marked "not-satisfied" and a remark will be created in the Assessment Report detailing the rationale.

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -3,6 +3,8 @@ package common
 import (
 	"fmt"
 	"os"
+
+	goversion "github.com/hashicorp/go-version"
 )
 
 func ReadFileToBytes(path string) ([]byte, error) {
@@ -17,4 +19,26 @@ func ReadFileToBytes(path string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+// Returns version validity
+func IsVersionValid(versionConstraint string, version string) (bool, error) {
+	if version == "unset" {
+		// Default cli version is "unset", enabling users to run directly from source code
+		// This is not a valid version, but we want to allow it for development purposes
+		return true, nil
+	}
+
+	currentVersion, err := goversion.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+	constraints, err := goversion.NewConstraint(versionConstraint)
+	if err != nil {
+		return false, err
+	}
+	if constraints.Check(currentVersion) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -2,9 +2,10 @@ package oscal
 
 import (
 	"fmt"
+	"strings"
 
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-	// "github.com/defenseunicorns/lula/src/config"
+	"github.com/defenseunicorns/lula/src/config"
 	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/types"
 	"gopkg.in/yaml.v3"
@@ -41,7 +42,7 @@ func BackMatterToMap(backMatter oscalTypes_1_1_2.BackMatter) map[string]types.Va
 			// Do version checking here to establish if the version is correct/acceptable
 			var result types.Result
 			var evaluated bool
-			currentVersion := "v0.0.2" //config.CLIVersion
+			currentVersion := strings.Split(config.CLIVersion, "-")[0]
 
 			versionConstraint := currentVersion
 			if description.LulaVersion != "" {

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -52,7 +52,7 @@ func BackMatterToMap(backMatter oscalTypes_1_1_2.BackMatter) map[string]types.Va
 			validVersion, versionErr := common.IsVersionValid(versionConstraint, currentVersion)
 			if versionErr != nil {
 				result.Failing = 1
-				result.Observations = map[string]string{"LulaVersion Error": versionErr.Error()}
+				result.Observations = map[string]string{"Lula Version Error": versionErr.Error()}
 				evaluated = true
 			} else if !validVersion {
 				result.Failing = 1

--- a/src/pkg/providers/opa/opa.go
+++ b/src/pkg/providers/opa/opa.go
@@ -146,7 +146,9 @@ func GetValidatedAssets(ctx context.Context, regoPolicy string, dataset map[stri
 			matchResult.Passing += 1
 		} else {
 			matchResult.Failing += 1
-			message.Debugf("Validation field expected bool and got %s", reflect.TypeOf(resultValid[0].Expressions[0].Value))
+			if !ok {
+				message.Debugf("Validation field expected bool and got %s", reflect.TypeOf(resultValid[0].Expressions[0].Value))
+			}
 		}
 	} else {
 		matchResult.Failing += 1

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -3,7 +3,7 @@ package types
 import "errors"
 
 type Description struct {
-	LulaVersion string                 `json:"lulaVersion" yaml:"lulaVersion"`
+	LulaVersion string                 `json:"lula-version" yaml:"lula-version"`
 	Target      map[string]interface{} `json:"target" yaml:"target"`
 }
 

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -2,6 +2,11 @@ package types
 
 import "errors"
 
+type Description struct {
+	LulaVersion string                 `json:"lulaVersion" yaml:"lulaVersion"`
+	Target      map[string]interface{} `json:"target" yaml:"target"`
+}
+
 type Validation struct {
 	Title       string                 `json:"title" yaml:"title"`
 	Description map[string]interface{} `json:"description" yaml:"description"`


### PR DESCRIPTION
Initial cut at specifying a Lula Version in the "Lula Validation" oscal fields. 
Changes
- New type `Description` for the description to be robust about marshaling that field
- New `IsVersionValid` function
- Updated component.go to do version checking
- Dependency on Hashicorp's go-version library to do the version constraint checking
  -> Since we are using their library, we are beholden to their rules - one of which is that version checks are just automatically denied when you compare a pre-release version to a non-prerelease constraint. I think the logic is that pre-release versions are possibly unstable and shouldn't be used. This creates some issues if building from a branch - which maybe should be discouraged but probably needs to be allowed for development(?). Anyway, needed to create a clean NON_PRERELEASE_VERSION in the Makefile to account for this... If there are other preferred solutions let me know