### PR TITLE
Feat: enable draft for release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,4 +49,4 @@ release:
     name: lula
   prerelease: auto
   mode: append
-  draft: false
+  draft: true


### PR DESCRIPTION
Closes #306 

Enables `draft` for github releases. After tag creation and push - this will create a draft release that the team can edit/review before officially publishing the latest release. 