### PR TITLE
Fix: set default CLI_VERSION to unset when no tags are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ INSTALL_PATH ?= /usr/local/bin
 GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_SHA    = $(shell git rev-parse --short HEAD)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
-CLI_VERSION ?= $(if $(shell git describe --tags),$(shell git describe --tags),"UnknownVersion")
+CLI_VERSION ?= $(if $(shell git describe --tags),$(shell git describe --tags),"unset")
 
 # Go CLI options
 PKG         := ./...


### PR DESCRIPTION
Closes #328 

Sets default to for `CLI_VERSION` to `unset` which passes the developer workflows for `make build` or `go run main.go` on forks of the project. 

Note that source of this change is from a fork that can be used for testing purposes.