### PR TITLE
feat: add triage label automation

### DIFF
--- a/.github/workflows/triage-label.yaml
+++ b/.github/workflows/triage-label.yaml
@@ -14,7 +14,6 @@ jobs:
     - name: Add triage label
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const issueNumber = context.issue.number;
           github.rest.issues.addLabels({

--- a/.github/workflows/triage-label.yaml
+++ b/.github/workflows/triage-label.yaml
@@ -1,0 +1,25 @@
+name: Issue Triage Label
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add triage label
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const issueNumber = context.issue.number;
+          github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issueNumber,
+            labels: ['triage']
+          });

--- a/docs/triage-label.md
+++ b/docs/triage-label.md
@@ -1,0 +1,34 @@
+## Using the Triage Label for Effective Issue Tracking
+
+### Overview
+
+In our efforts to streamline the management and resolution of issues, we introduce the use of the **triage** label. This label is an integral part of our issue tracking system, aimed at improving the efficiency and effectiveness with which we handle reported issues, feature requests, and other tasks within our projects.
+
+### Purpose of the Triage Label
+
+The **triage** label serves several key purposes:
+
+- **Prioritization:** It helps in quickly identifying new issues that need to be assessed for their urgency and impact. This initial sorting ensures that critical issues are addressed promptly.
+- **Clarity:** Applying the triage label to new issues clarifies that they are awaiting review. It prevents duplication of work and ensures that every issue is considered by the appropriate team members.
+- **Efficiency:** By categorizing issues into different priorities and types during the triage process, we can allocate our resources more effectively, focusing on what matters most.
+- **Tracking:** The triage process allows us to better track the progress of issues from their inception through to resolution, offering clear visibility into the status and handling of every report.
+
+### Process
+
+1. **Applying the Triage Label:**
+   - All newly created issues should automatically receive the **triage** label. If not, team members are encouraged to manually apply the label when they encounter an unlabelled new issue.
+
+2. **Label Adjustment:**
+   - Following the triage by a dev, the **triage** label will be replaced or supplemented with additional labels reflecting the issue's priority, type (bug, feature request, etc.), and the assigned owner, team, or appropriate category.
+
+3. **Issue Resolution:**
+   - As work progresses, the assigned individuals will update the issue with their findings, solutions, and any other relevant labels until the issue is resolved.
+
+### Best Practices
+
+- **Prompt Labeling:** Ensure all new issues are promptly labeled with **triage** to avoid delays in their review and handling.
+- **Clear Communication:** Use the issue comments to provide clear and concise updates, including any changes in priority or additional labels added post-triage.
+
+### Conclusion
+
+The **triage** label is a cornerstone of our issue tracking system, designed to enhance our team's ability to manage issues efficiently and effectively. By following this process, we can ensure that all issues receive the attention they need, resources are allocated optimally, and our projects move forward smoothly.


### PR DESCRIPTION
Added GitHub work flow to add the triage label to any opened or reopened issues in the repo.