### PR TITLE
feat: Establish workflow for lula validation identifiers

### DIFF
--- a/demo/oscal-component-kyverno.yaml
+++ b/demo/oscal-component-kyverno.yaml
@@ -36,12 +36,10 @@ component-definition:
           This control validates that the demo-pod pod in the validation-test namespace contains the required pod label foo=bar in order to establish compliance.
         links:
           - href: '#a7377430-2328-4dc4-a9e2-b3f31dc1dff9'
-            rel: reference
-            text: Lula Validation
+            rel: lula
   back-matter: 
     resources:
     - uuid: a7377430-2328-4dc4-a9e2-b3f31dc1dff9
-      title: Lula Validation
       rlinks:
         - href: lula.dev
       description: >-

--- a/demo/oscal-component-opa.yaml
+++ b/demo/oscal-component-opa.yaml
@@ -36,12 +36,10 @@ component-definition:
           This control validates that the demo-pod pod in the validation-test namespace contains the required pod label foo=bar in order to establish compliance.
         links:
           - href: '#a7377430-2328-4dc4-a9e2-b3f31dc1dff9'
-            rel: reference
-            text: Lula Validation
+            rel: lula
   back-matter: 
     resources:
     - uuid: a7377430-2328-4dc4-a9e2-b3f31dc1dff9
-      title: Lula Validation
       rlinks:
         - href: lula.dev
       description: >-

--- a/docs/oscal-validation-links.md
+++ b/docs/oscal-validation-links.md
@@ -1,0 +1,73 @@
+# Validation Identifiers
+
+In OSCAL - `links` contains the following fields:
+```yaml
+links:
+  - href: https://www.example.com/
+    rel: reference
+    text: Example
+    media-type: text/html
+    resource-fragment: some-fragment
+```
+
+These links are a "reference to a local or remote resource, that has a specific relation to the containing object" - [Component Definition Links](https://pages.nist.gov/OSCAL-Reference/models/v1.1.2/component-definition/json-reference/#/component-definition/components/links).
+
+As such, links are a native OSCAL attribute that Lula can use to map to Validations. 
+
+## Connecting Links with Lula Validations
+
+After identifying a control and writing a Lula Validation, we need to store that Lula Validation within the OSCAL artifact for referencing.
+
+This is accomplished by adding a new `resource` to the `back-matter` as shown below:
+
+```yaml
+back-matter:
+  resources:
+  - uuid: a7377430-2328-4dc4-a9e2-b3f31dc1dff9
+    title: Lula Validation
+    rlinks:
+      - href: lula.dev
+    description: >-
+      domain:
+        type: kubernetes
+        kubernetes-spec:
+          resources:
+          - name: podsvt 
+            resource-rule:   
+              group: 
+              version: v1
+              resource: pods
+              namespaces: [validation-test] 
+      provider: 
+        type: opa
+        opa-spec:
+          rego: |
+            package validate
+
+            import future.keywords.every
+
+            validate {
+              every pod in input.podsvt {
+                podLabel := pod.metadata.labels.foo
+                podLabel == "bar"
+              }
+            }
+```
+
+Now we need to map an existing control (or Component-Definition Implemented-Requirement) to this Lula Validation. 
+
+### Rel
+The default workflow is to use the rel attribute to indicate that Lula has work to perform.
+
+In the instance of a standard validation - A link to a Lula Validation might look like this:
+```yaml
+links:
+  - href: '#a7377430-2328-4dc4-a9e2-b3f31dc1dff9'
+    rel: lula
+```
+
+Where `href: '#a7377430-2328-4dc4-a9e2-b3f31dc1dff9'` points to an OSCAL object with a UUID reference and `rel: lula` indicates that the link is to a Lula Validation.
+UUID's should always be unique per object in the OSCAL artifact.
+
+> [!TIP]
+> You can generate a random UUID using `lula tools uuidgen` or a deterministic UUID using `lula tools uuidgen <string>`.

--- a/docs/oscal-validation-links.md
+++ b/docs/oscal-validation-links.md
@@ -24,9 +24,6 @@ This is accomplished by adding a new `resource` to the `back-matter` as shown be
 back-matter:
   resources:
   - uuid: a7377430-2328-4dc4-a9e2-b3f31dc1dff9
-    title: Lula Validation
-    rlinks:
-      - href: lula.dev
     description: >-
       domain:
         type: kubernetes

--- a/docs/version-specification.md
+++ b/docs/version-specification.md
@@ -2,7 +2,6 @@
 In cases where a specific version of Lula is desired, either for typing constraints or desired functionality, a `lula-version` property is recognized in the `description` (component-definition.back-matter.resources[_]):
 ```yaml
 - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-  title: Lula Validation
   remarks: >-
     No outputs in payload
   description: |

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/defenseunicorns/lula/src/types"
@@ -98,7 +99,7 @@ func ValidateOnPath(path string) (findingMap map[string]oscalTypes_1_1_2.Finding
 
 	_, err = os.Stat(path)
 	if os.IsNotExist(err) {
-		return findingMap, observations, fmt.Errorf("Path: %v does not exist - unable to digest document\n", path)
+		return findingMap, observations, fmt.Errorf("path: %v does not exist - unable to digest document", path)
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -123,8 +124,12 @@ func ValidateOnPath(path string) (findingMap map[string]oscalTypes_1_1_2.Finding
 // It will perform a validation and add data to a referenced report object
 func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string]oscalTypes_1_1_2.Finding, []oscalTypes_1_1_2.Observation, error) {
 
-	// Populate a map[uuid]Validation into the validations
-	validations := oscal.BackMatterToMap(*compDef.BackMatter)
+	// Populate a map[uuid]string for back-matter.resources
+	// This is pre-poulated for on-demand use when referencing the back-matter from a link
+	backMatterMap := oscal.BackMatterToMap(*compDef.BackMatter)
+
+	// Populate a map for storing validations
+	validationMap := make(map[string]types.LulaValidation)
 
 	// Loops all the way down
 
@@ -169,11 +174,10 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 				if implementedRequirement.Links != nil {
 					for _, link := range *implementedRequirement.Links {
 						var result types.Result
-						var domainResources types.DomainResources
 						var err error
-						// Current identifier is the link text
-						// TODO: define workflow/purpose for this -> depending on link.Text, use different val.LulaValidationType?
-						if link.Text == "Lula Validation" {
+						// TODO: potentially use rel to determine the type of validation (Validation Types discussion)
+						rel := strings.Split(link.Rel, ".")
+						if link.Text == "Lula Validation" || rel[0] == "lula" {
 							sharedUuid := uuid.NewUUID()
 							observation := oscalTypes_1_1_2.Observation{
 								Collected: rfc3339Time,
@@ -181,31 +185,42 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 								UUID:      sharedUuid,
 							}
 							// Remove the leading '#' from the UUID reference
+							// TODO: add the ability to process Href for entries other than UUID
+							// If this is an external validations document - Check the validationMap for the UUID first
+							// If the validation uuid doesn't exist - read the external document and add all validations within to the validationMap
 							id := strings.Replace(link.Href, "#", "", 1)
 							observation.Description = fmt.Sprintf("[TEST] %s - %s\n", implementedRequirement.ControlId, id)
 							// Check if the link exists in our pre-populated map of validations
-							if val, ok := validations[id]; ok {
+							if val, ok := validationMap[id]; ok {
 								// If the validation has already been evaluated, use the result from the evaluation - otherwise perform the validation
 								if val.Evaluated {
 									result = val.Result
 								} else {
-									// Extract the resources from the domain
-									domainResources, err = val.Domain.GetResources()
+									err = val.Validate()
 									if err != nil {
-										message.Fatalf(err, "error getting domain resources: %s", err.Error())
-									}
-									// Perform the evaluation using the provider
-									result, err = val.Provider.Evaluate(domainResources)
-									if err != nil {
+										// TODO: we should probably create an error string and add that to the result instead of returning
 										return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
 									}
-									// Store the result in the validation object
-									val.Result = result
-									val.Evaluated = true
-									validations[id] = val
+									result = val.Result
+									validationMap[id] = val
 								}
+							} else if description, ok := backMatterMap[id]; ok {
+								// Resource is in the backmatter - create a validation
+								val, err := common.ValidationFromString(description)
+								if err != nil {
+									// TODO: we should probably create an error string and add that to the result instead of returning
+									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
+								}
+
+								err = val.Validate()
+								if err != nil {
+									// TODO: we should probably create an error string and add that to the result instead of returning
+									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
+								}
+								result = val.Result
+								validationMap[id] = val
 							} else {
-								return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, fmt.Errorf("Back matter Validation %v not found", id)
+								return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, fmt.Errorf("back matter Validation %v not found", id)
 							}
 
 							// Individual result state

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
+	"github.com/defenseunicorns/lula/src/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -172,10 +173,6 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 
 				if implementedRequirement.Links != nil {
 					for _, link := range *implementedRequirement.Links {
-<<<<<<< HEAD
-						var result types.Result
-=======
->>>>>>> 5c2eb651e0cd4dcbdf545a5617bab9d35f7a7b97
 						var err error
 						// TODO: potentially use rel to determine the type of validation (Validation Types discussion)
 						rel := strings.Split(link.Rel, ".")
@@ -193,19 +190,14 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 							id := strings.Replace(link.Href, "#", "", 1)
 							observation.Description = fmt.Sprintf("[TEST] %s - %s\n", implementedRequirement.ControlId, id)
 							// Check if the link exists in our pre-populated map of validations
-							if val, ok := validationMap[id]; ok {
-								// If the validation has already been evaluated, use the result from the evaluation - otherwise perform the validation
-								if val.Evaluated {
-									result = val.Result
-								} else {
-									err = val.Validate()
-									if err != nil {
-										// TODO: we should probably create an error string and add that to the result instead of returning
-										return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
-									}
-									result = val.Result
-									validationMap[id] = val
+							val, ok := validationMap[id]
+							if ok {
+								err = val.Validate()
+								if err != nil {
+									// TODO: we should probably create an error string and add that to the result instead of returning
+									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
 								}
+								validationMap[id] = val
 							} else if description, ok := backMatterMap[id]; ok {
 								// Resource is in the backmatter - create a validation
 								val, err := common.ValidationFromString(description)
@@ -219,12 +211,10 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 									// TODO: we should probably create an error string and add that to the result instead of returning
 									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
 								}
-								result = val.Result
 								validationMap[id] = val
 							} else {
 								return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, fmt.Errorf("back matter Validation %v not found", id)
 							}
-
 							// Individual result state
 							if val.Result.Passing > 0 && val.Result.Failing <= 0 {
 								val.Result.State = "satisfied"

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -200,7 +200,7 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 								validationMap[id] = val
 							} else if description, ok := backMatterMap[id]; ok {
 								// Resource is in the backmatter - create a validation
-								val, err := common.ValidationFromString(description)
+								val, err = common.ValidationFromString(description)
 								if err != nil {
 									// TODO: we should probably create an error string and add that to the result instead of returning
 									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -102,41 +102,10 @@ func ValidationFromString(raw string) (validation types.LulaValidation, err erro
 		return validation, err
 	}
 
-	// Do version checking here to establish if the version is correct/acceptable
-	var result types.Result
-	var evaluated bool
-	currentVersion := strings.Split(config.CLIVersion, "-")[0]
-
-	versionConstraint := currentVersion
-	if validationData.LulaVersion != "" {
-		versionConstraint = validationData.LulaVersion
+	validation, err = validationData.ToLulaValidation()
+	if err != nil {
+		return validation, err
 	}
-
-	validVersion, versionErr := IsVersionValid(versionConstraint, currentVersion)
-	if versionErr != nil {
-		result.Failing = 1
-		result.Observations = map[string]string{"Lula Version Error": versionErr.Error()}
-		evaluated = true
-	} else if !validVersion {
-		result.Failing = 1
-		result.Observations = map[string]string{"Version Constraint Incompatible": "Lula Version does not meet the constraint for this validation."}
-		evaluated = true
-	}
-
-	// Construct the validation object
-	ctx := context.Background()
-	validation.Provider = GetProvider(validationData.Provider, ctx)
-	if validation.Provider == nil {
-		// Use of Fatalf() here will exit the runtime - do we want to log this instead?
-		return validation, fmt.Errorf("provider %s not found", validationData.Provider.Type)
-	}
-	validation.Domain = GetDomain(validationData.Domain, ctx)
-	if validation.Domain == nil {
-		return validation, fmt.Errorf("domain %s not found", validationData.Domain.Type)
-	}
-	validation.LulaValidationType = types.DefaultLulaValidationType // TODO: define workflow/purpose for this
-	validation.Evaluated = evaluated
-	validation.Result = result
 
 	return validation, nil
 }

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/defenseunicorns/lula/src/config"
 	"github.com/defenseunicorns/lula/src/pkg/domains/api"
 	kube "github.com/defenseunicorns/lula/src/pkg/domains/kubernetes"
 	"github.com/defenseunicorns/lula/src/pkg/message"

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -90,6 +90,10 @@ func GetProvider(provider Provider, ctx context.Context) types.Provider {
 
 // Converts a raw string to a Validation object (string -> common.Validation -> types.Validation)
 func ValidationFromString(raw string) (validation types.LulaValidation, err error) {
+	if raw == "" {
+		return validation, fmt.Errorf("validation string is empty")
+	}
+
 	var validationData Validation
 
 	err = yaml.Unmarshal([]byte(raw), &validationData)
@@ -124,11 +128,11 @@ func ValidationFromString(raw string) (validation types.LulaValidation, err erro
 	validation.Provider = GetProvider(validationData.Provider, ctx)
 	if validation.Provider == nil {
 		// Use of Fatalf() here will exit the runtime - do we want to log this instead?
-		message.Fatalf(nil, "provider %s not found", validationData.Provider.Type)
+		return validation, fmt.Errorf("provider %s not found", validationData.Provider.Type)
 	}
 	validation.Domain = GetDomain(validationData.Domain, ctx)
 	if validation.Domain == nil {
-		message.Fatalf(nil, "domain %s not found", validationData.Domain.Type)
+		return validation, fmt.Errorf("domain %s not found", validationData.Domain.Type)
 	}
 	validation.LulaValidationType = types.DefaultLulaValidationType // TODO: define workflow/purpose for this
 	validation.Evaluated = evaluated

--- a/src/pkg/common/common_test.go
+++ b/src/pkg/common/common_test.go
@@ -164,3 +164,51 @@ func TestGetProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestValidationFromString(t *testing.T) {
+	validBackMatterMapBytes := loadTestData(t, "../../test/unit/common/oscal/valid-back-matter-map.yaml")
+
+	var validBackMatterMap map[string]string
+	if err := yaml.Unmarshal(validBackMatterMapBytes, &validBackMatterMap); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+
+	validationStrings := make([]string, 0)
+	for _, v := range validBackMatterMap {
+		validationStrings = append(validationStrings, v)
+	}
+
+	tests := []struct {
+		name    string
+		data    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid Validation string",
+			data:    validationStrings[0],
+			wantErr: false,
+		},
+		{
+			name:    "Invalid Validation string",
+			data:    "Test: test",
+			wantErr: true,
+		},
+		{
+			name:    "Empty Data",
+			data:    "",
+			wantErr: true,
+		},
+		// Additional test cases can be added here
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := common.ValidationFromString(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidationFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+}

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -1,15 +1,10 @@
 package oscal
 
 import (
-	"context"
 	"fmt"
-	"strings"
 
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-	"github.com/defenseunicorns/lula/src/config"
-	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/message"
-	"github.com/defenseunicorns/lula/src/types"
 
 	"sigs.k8s.io/yaml"
 )
@@ -25,73 +20,28 @@ func NewOscalComponentDefinition(data []byte) (componentDefinition oscalTypes_1_
 	}
 
 	if oscalModels.ComponentDefinition == nil {
-		return componentDefinition, fmt.Errorf("No Component Definition found in the provided data")
+		return componentDefinition, fmt.Errorf("no Component Definition found in the provided data")
 	}
 
 	return *oscalModels.ComponentDefinition, nil
 }
 
-// Map an array of resources to a map of UUID to lulaValidation object
-func BackMatterToMap(backMatter oscalTypes_1_1_2.BackMatter) map[string]types.LulaValidation {
-	resourceMap := make(map[string]types.LulaValidation)
-
+// Returns a map of the uuid - description of the back-matter resources
+func BackMatterToMap(backMatter oscalTypes_1_1_2.BackMatter) (resourceMap map[string]string) {
 	if backMatter.Resources == nil {
 		return nil
 	}
 
+	resourceMap = make(map[string]string)
 	for _, resource := range *backMatter.Resources {
-		// TODO: Possibly support different title values (e.g., "Placeholder", "Healthcheck")
-		if resource.Title == "Lula Validation" {
-			var validation common.Validation
-			var lulaValidation types.LulaValidation
-
-			err := yaml.Unmarshal([]byte(resource.Description), &validation)
-			if err != nil {
-				message.Fatalf(err, "error unmarshalling yaml: %s", err.Error())
-				return nil
-			}
-
-			// Do version checking here to establish if the version is correct/acceptable
-			var result types.Result
-			var evaluated bool
-			currentVersion := strings.Split(config.CLIVersion, "-")[0]
-
-			versionConstraint := currentVersion
-			if validation.LulaVersion != "" {
-				versionConstraint = validation.LulaVersion
-			}
-
-			validVersion, versionErr := common.IsVersionValid(versionConstraint, currentVersion)
-			if versionErr != nil {
-				result.Failing = 1
-				result.Observations = map[string]string{"Lula Version Error": versionErr.Error()}
-				evaluated = true
-			} else if !validVersion {
-				result.Failing = 1
-				result.Observations = map[string]string{"Version Constraint Incompatible": "Lula Version does not meet the constraint for this validation."}
-				evaluated = true
-			}
-
-			// Construct the lulaValidation object
-			// TODO: Is there a better location for context?
-			ctx := context.Background()
-			lulaValidation.Provider = common.GetProvider(validation.Provider, ctx)
-			if lulaValidation.Provider == nil {
-				message.Fatalf(nil, "provider %s not found", validation.Provider.Type)
-				return nil
-			}
-			lulaValidation.Domain = common.GetDomain(validation.Domain, ctx)
-			if lulaValidation.Domain == nil {
-				message.Fatalf(nil, "domain %s not found", validation.Domain.Type)
-				return nil
-			}
-			lulaValidation.LulaValidationType = types.DefaultLulaValidationType // TODO: define workflow/purpose for this
-			lulaValidation.Evaluated = evaluated
-			lulaValidation.Result = result
-
-			resourceMap[resource.UUID] = lulaValidation
+		// perform a check to see if the key already exists (meaning duplicitive uuid use)
+		_, exists := resourceMap[resource.UUID]
+		if exists {
+			message.Warnf("Duplicative UUID use detected - Overwriting UUID %s", resource.UUID)
 		}
 
+		resourceMap[resource.UUID] = resource.Description
 	}
 	return resourceMap
+
 }

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-<<<<<<< HEAD
-=======
-	"github.com/defenseunicorns/lula/src/pkg/common"
->>>>>>> 5c2eb651e0cd4dcbdf545a5617bab9d35f7a7b97
 	"github.com/defenseunicorns/lula/src/pkg/message"
 
 	"sigs.k8s.io/yaml"

--- a/src/pkg/common/oscal/component_test.go
+++ b/src/pkg/common/oscal/component_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"gopkg.in/yaml.v3"
 )
@@ -24,20 +23,42 @@ func loadTestData(t *testing.T, path string) []byte {
 }
 
 func TestBackMatterToMap(t *testing.T) {
-	data := loadTestData(t, validComponentPath)
-	var component oscalTypes_1_1_2.OscalCompleteSchema
-	err := yaml.Unmarshal(data, &component)
-	if err != nil {
+	validComponentBytes := loadTestData(t, validComponentPath)
+	validBackMatterMapBytes := loadTestData(t, "../../../test/unit/common/oscal/valid-back-matter-map.yaml")
+
+	var validComponent oscalTypes.OscalCompleteSchema
+	if err := yaml.Unmarshal(validComponentBytes, &validComponent); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+	var validBackMatterMap map[string]string
+	if err := yaml.Unmarshal(validBackMatterMapBytes, &validBackMatterMap); err != nil {
 		t.Fatalf("yaml.Unmarshal failed: %v", err)
 	}
 
-	got := oscal.BackMatterToMap(*component.ComponentDefinition.BackMatter)
-	if got == nil {
-		t.Fatalf("BackMatterToMap returned nil")
+	tests := []struct {
+		name       string
+		backMatter oscalTypes.BackMatter
+		want       map[string]string
+	}{
+		{
+			name:       "Test No Resources",
+			backMatter: oscalTypes.BackMatter{},
+		},
+		{
+			name:       "Test Valid Component",
+			backMatter: *validComponent.ComponentDefinition.BackMatter,
+			want:       validBackMatterMap,
+		},
+		// Add more test cases as needed
 	}
 
-	if len(got) == 0 {
-		t.Fatalf("BackMatterToMap returned empty map")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oscal.BackMatterToMap(tc.backMatter)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("BackMatterToMap() got = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/src/test/e2e/scenarios/api-field/oscal-component.yaml
+++ b/src/test/e2e/scenarios/api-field/oscal-component.yaml
@@ -39,12 +39,10 @@ component-definition:
           dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         links:
         - href: '#C30E849E-C262-42DF-8C84-EA1B62A6AD90'
-          rel: reference
-          text: Lula Validation
+          rel: lula
   back-matter: 
     resources:
     - uuid: C30E849E-C262-42DF-8C84-EA1B62A6AD90
-      title: Lula Validation
       description: >-
         domain:
           type: api

--- a/src/test/e2e/scenarios/multi-resource/oscal-component.yaml
+++ b/src/test/e2e/scenarios/multi-resource/oscal-component.yaml
@@ -39,15 +39,12 @@ component-definition:
           dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         links:
         - href: '#88AB3470-B96B-4D7C-BC36-02BF9563C46C'
-          rel: reference
-          text: Lula Validation
+          rel: lula
         - href: '#F9EC74AE-19A0-4822-8D7C-214AECCEB7C6'
-          rel: reference
-          text: Lula Validation
+          rel: lula
   back-matter: 
     resources:
     - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-      title: Lula Validation
       description: >-
         domain: 
           type: kubernetes
@@ -83,7 +80,6 @@ component-definition:
                 }
               }
     - uuid: F9EC74AE-19A0-4822-8D7C-214AECCEB7C6
-      title: Lula Validation
       description: >-
         domain: 
           type: api

--- a/src/test/e2e/scenarios/outputs/oscal-component.yaml
+++ b/src/test/e2e/scenarios/outputs/oscal-component.yaml
@@ -36,19 +36,17 @@ component-definition:
         description: Test
         links:
         - href: '#17c5f855-4f7b-4545-aa1c-cd01f416c290'
-          rel: reference
+          rel: lula
           text: Lula Validation
       - uuid: 18800e54-517b-4078-85c4-847e4977b82c
         control-id: ID-2
         description: Test
         links:
         - href: '#67993bda-95e2-431e-8384-0cf34dd7ce49'
-          rel: reference
-          text: Lula Validation
+          rel: lula
   back-matter: 
     resources:
     - uuid: 17c5f855-4f7b-4545-aa1c-cd01f416c290
-      title: Lula Validation
       remarks: >-
         Validate that outputs in are tied to the validation evaluation and post to remarks
       description: >-
@@ -81,7 +79,6 @@ component-definition:
               observations:
               - validate.test
     - uuid: 67993bda-95e2-431e-8384-0cf34dd7ce49
-      title: Lula Validation
       remarks: >-
         Validate that bad outputs are handled and result in not satisfied result
       description: >-

--- a/src/test/e2e/scenarios/pod-label/oscal-component-kyverno.yaml
+++ b/src/test/e2e/scenarios/pod-label/oscal-component-kyverno.yaml
@@ -38,8 +38,7 @@ component-definition:
                 dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               links:
                 - href: "#88AB3470-B96B-4D7C-BC36-02BF9563C46C"
-                  rel: reference
-                  text: Lula Validation
+                  rel: lula
             - uuid: 86a0e8d9-0ce0-4304-afe7-4c000001e032
               control-id: ID-2
               description: >-
@@ -48,12 +47,10 @@ component-definition:
                 dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               links:
                 - href: "#01e21994-2cfc-45fb-ac84-d00f2e5912b0"
-                  rel: reference
-                  text: Lula Validation
+                  rel: lula
   back-matter:
     resources:
       - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-        title: Lula Validation
         description: >-
           domain: 
             type: kubernetes
@@ -83,7 +80,6 @@ component-definition:
                               labels:
                                 foo: bar
       - uuid: 01e21994-2cfc-45fb-ac84-d00f2e5912b0
-        title: Lula Validation
         description: >-
           domain: 
             type: kubernetes

--- a/src/test/e2e/scenarios/pod-label/oscal-component.yaml
+++ b/src/test/e2e/scenarios/pod-label/oscal-component.yaml
@@ -38,8 +38,7 @@ component-definition:
                 dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               links:
                 - href: "#88AB3470-B96B-4D7C-BC36-02BF9563C46C"
-                  rel: reference
-                  text: Lula Validation
+                  rel: lula
             - uuid: 86a0e8d9-0ce0-4304-afe7-4c000001e032
               control-id: ID-2
               description: >-
@@ -48,12 +47,10 @@ component-definition:
                 dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               links:
                 - href: "#01e21994-2cfc-45fb-ac84-d00f2e5912b0"
-                  rel: reference
-                  text: Lula Validation
+                  rel: lula
   back-matter:
     resources:
       - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-        title: Lula Validation
         description: >-
           domain: 
             type: kubernetes
@@ -79,7 +76,6 @@ component-definition:
                   }
                 }
       - uuid: 01e21994-2cfc-45fb-ac84-d00f2e5912b0
-        title: Lula Validation
         description: >-
           domain: 
             type: kubernetes

--- a/src/test/e2e/scenarios/resource-data/oscal-component.yaml
+++ b/src/test/e2e/scenarios/resource-data/oscal-component.yaml
@@ -39,12 +39,10 @@ component-definition:
           dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         links:
         - href: '#88AB3470-B96B-4D7C-BC36-02BF9563C46C'
-          rel: reference
-          text: Lula Validation
+          rel: lula
   back-matter: 
     resources:
     - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-      title: Lula Validation
       remarks: >-
         Get data for all resources fields specified
       description: >-

--- a/src/test/e2e/scenarios/wait-field/oscal-component.yaml
+++ b/src/test/e2e/scenarios/wait-field/oscal-component.yaml
@@ -39,12 +39,10 @@ component-definition:
           dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         links:
         - href: '#88AB3470-B96B-4D7C-BC36-02BF9563C46C'
-          rel: reference
-          text: Lula Validation
+          rel: lula
   back-matter: 
     resources:
     - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-      title: Lula Validation
       description: >-
         domain: 
           type: kubernetes

--- a/src/test/unit/common/oscal/valid-back-matter-map.yaml
+++ b/src/test/unit/common/oscal/valid-back-matter-map.yaml
@@ -1,0 +1,56 @@
+88AB3470-B96B-4D7C-BC36-02BF9563C46C: >-
+  domain: 
+    type: kubernetes
+    kubernetes-spec:
+      resources:
+      - name: jsoncm
+        resource-rule:
+          name: configmap-json
+          version: v1
+          resource: configmaps
+          namespaces: [validation-test]
+          field:
+            jsonpath: .data.person.json
+            type: yaml
+      - name: yamlcm
+        resource-rule:
+          name: configmap-yaml
+          version: v1
+          resource: configmaps
+          namespaces: [validation-test]
+          field:
+            jsonpath: .data.app-config.yaml
+            type: yaml
+      - name: secret
+        resource-rule:
+          name: example-secret
+          version: v1
+          resource: secrets
+          namespaces: [validation-test]
+          field:
+            jsonpath: .data.auth
+            type: yaml
+            base64: true
+      - name: pod
+        resource-rule:
+          name: example-pod
+          version: v1
+          resource: pods
+          namespaces: [validation-test]
+          field:
+            jsonpath: .metadata.annotations.annotation.io/simple
+            type: json
+  provider: 
+    type: opa
+    opa-spec:
+      rego: |
+        package validate
+
+        import future.keywords.every
+
+        validate {
+          input.jsoncm.name == "bob"
+          input.yamlcm.logging.level == "INFO"
+          input.secret.username == "username"
+          "item1" in input.pod.items
+        }

--- a/src/test/unit/common/oscal/valid-component.yaml
+++ b/src/test/unit/common/oscal/valid-component.yaml
@@ -38,12 +38,10 @@ component-definition:
                 dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               links:
                 - href: "#88AB3470-B96B-4D7C-BC36-02BF9563C46C"
-                  rel: reference
-                  text: Lula Validation
+                  rel: lula
   back-matter:
     resources:
       - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
-        title: Lula Validation
         remarks: >-
           Get data for all resources fields specified
         description: >-


### PR DESCRIPTION
Closes #226 

Improving the validation identifiers to improve the developer experience and reduce potential errors due to miss identifying a link. 

## Changes 
- Provide better separation between the OSCAL and Lula validations
  - `BackMatterToMap()` now strictly provides a map[string]string object for which identified validations will then be unmarshalled and placed in the `validationMap`. 
    - This removes the need to place any identifier in the `back-matter` validation
    - This also provides a greater separation from OSCAL functionality and Lula Validation functionality
- Currently backwards compatible - this can be discussed and removed
- Establishes the use of `rel` for which we _could_ expand to include validation "types"
- `validationMap` serves future external processing - such that when an external document is unmarshalled, we can place 1 -> N validations into the map rather than having to open the same file multiple times for different validations (reuse).
- Move the unmarshall and validation of a Validation from a String (back-matter.resource[_].description) to the common package to delineate that functionality from OSCAL functionality. 