### PR TITLE
fix: remove homebrew for future updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,14 +91,6 @@ jobs:
           name: build-artifacts
           path: bin/
 
-      - name: Get Brew tap repo token
-        id: brew-tap-token
-        uses: peter-murray/workflow-application-token-action@dc0413987a085fa17d19df9e47d4677cf81ffef3 # v3.0.0
-        with:
-          application_id: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_ID }}
-          application_private_key: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_SECRET }}
-          organization: defenseunicorns
-
       # Create the GitHub release notes
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
@@ -108,4 +100,3 @@ jobs:
           args: release --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,27 +42,6 @@ snapshot:
 changelog:
   use: github-native
 
-brews:
-  - name: lula
-    repository:
-      owner: defenseunicorns
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/defenseunicorns/lula"
-    description: "The Compliance Validator"
-
-  # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
-  #       install versioned releases that has a `v` character before the version number.
-  - name: "lula@{{ .Version }}"
-    repository:
-      owner: defenseunicorns
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} versioned release {{ .Tag }}"
-    homepage: "https://github.com/defenseunicorns/lula"
-    description: "The Compliance Validator"
-
 # Generate a GitHub release and publish the release for the tag
 release:
   github:


### PR DESCRIPTION
## Description
Remove homebrew for now until we update to approved workflows.

We have no documentation to-date about our homebrew installation and we want to migrate to approved workflows for token retrieval and signing. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed