### PR TITLE
feat: initial poc for report

### DIFF
--- a/src/cmd/report/common.go
+++ b/src/cmd/report/common.go
@@ -1,0 +1,16 @@
+package report
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var reportCmd = &cobra.Command{
+	Use:     "report",
+	Aliases: []string{"r"},
+	Short:   "Collection of report commands to make assessor life easier",
+}
+
+// Include adds the tools command to the root command.
+func Include(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(reportCmd)
+}

--- a/src/cmd/report/component-definition.go
+++ b/src/cmd/report/component-definition.go
@@ -1,17 +1,12 @@
 package report
 
 import (
-	// "bytes"
 	"errors"
 	"fmt"
 	"os"
 	"encoding/json"
-	// "strings"
-	// "time"
 
-	// "github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-	// "github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -101,7 +96,6 @@ func init() {
 }
 	reportCmd.AddCommand(componentDefinitionCmd)
 
-	// insert flag options here
 	componentDefinitionCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to the target OSCAL component definition")
 	componentDefinitionCmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "o", "json", "the output format of the report")
 	componentDefinitionCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "w", "", "the output file path for the report")

--- a/src/cmd/report/component-definition.go
+++ b/src/cmd/report/component-definition.go
@@ -1,0 +1,196 @@
+package report
+
+import (
+	// "bytes"
+	"errors"
+	"fmt"
+	"os"
+	"encoding/json"
+	// "strings"
+	// "time"
+
+	// "github.com/defenseunicorns/go-oscal/src/pkg/uuid"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	// "github.com/defenseunicorns/lula/src/pkg/common/oscal"
+	"github.com/defenseunicorns/lula/src/pkg/message"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type flags struct {
+	InputFile      string // -f --input-file
+	Summary        bool // -s --summary
+	Detailed	   bool // -d --detailed
+	OutputFormat   string // -o --output-format
+	OutputFile     string // -w --output-file
+	// OutputFormat string // -fmt --format									<---- Possible flag option
+
+	// WriteFile   string // -w --write-file                                <---- Possible flag option
+	// OutputFile   string // -o --output-file                              <---- Possible flag option
+}
+
+var opts = &flags{}
+
+type ReportData struct {
+    Detailed   *DetailedReportData `json:"Detailed,omitempty" yaml:"Detailed,omitempty"`
+    Summary    *SummaryReportData  `json:"Summary,omitempty" yaml:"Summary,omitempty"`
+}
+
+type DetailedReportData struct {
+    ControlIDCounts map[string]int
+    // other detailed specific data fields
+}
+
+type SummaryReportData struct {
+    // other summary specific data fields
+}
+
+var componentDefinitionHelp = `
+To create a summary report of a component-definition:
+	lula report component-definition -f ./oscal-component.yaml -s
+
+To create a detailed report of a component-definition:
+	lula report component-definition -f ./oscal-component.yaml -d
+`
+func init() {
+	componentDefinitionCmd := &cobra.Command{
+	Use:     "component-definition",
+	Short:   "Report on an OSCAL component definition",
+	Long:    "Detailed or Summary report of an OSCAL component definition",
+	Example: componentDefinitionHelp,
+	Run: func(cmd *cobra.Command, args []string) {
+		if opts.InputFile == "" {
+			message.Fatal(errors.New("flag input-file is not set"),
+				"Please specify an input file with the -f flag")
+		}
+
+		oscalModels, err := loadComponentDefinitionFromFile(opts.InputFile)
+		if err != nil {
+			message.Fatal(err, "Failed to unmarshall OSCAL from Component Definition")
+		}
+
+		var reportData ReportData
+
+		if opts.Detailed {
+			fmt.Println("Generating detailed report in", opts.OutputFormat)
+			reportData.Detailed = countControlIDs(oscalModels)
+			fmt.Println("Control IDs count is:", reportData.Detailed.ControlIDCounts)
+
+		}
+
+		if opts.Summary {
+			fmt.Println("Generating summary report in", opts.OutputFormat)
+			// Add Reporting Logic
+		}
+
+		// Always print to stdout
+		err = PrintReport(reportData, opts.OutputFormat)
+		if err != nil {
+			message.Fatal(err, "Failed to print report")
+		}
+
+		if opts.OutputFile != "" && (reportData.Detailed != nil || reportData.Summary != nil) {
+        err = WriteReport(reportData, opts.OutputFile, opts.OutputFormat)
+        if err != nil {
+            message.Fatal(err, "Failed to write report to file")
+        }
+        fmt.Println("Report successfully written to", opts.OutputFile)
+    }
+
+	},
+}
+	reportCmd.AddCommand(componentDefinitionCmd)
+
+	// insert flag options here
+	componentDefinitionCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to the target OSCAL component definition")
+	componentDefinitionCmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "o", "json", "the output format of the report")
+	componentDefinitionCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "w", "", "the output file path for the report")
+	componentDefinitionCmd.Flags().BoolVarP(&opts.Detailed, "detailed", "d", false, "create the detailed component definition report")
+	componentDefinitionCmd.Flags().BoolVarP(&opts.Summary, "summary", "s", false, "create the summary component definition report")
+
+}
+
+func loadComponentDefinitionFromFile(filename string) (oscalTypes_1_1_2.OscalModels, error) {
+    var oscalModels oscalTypes_1_1_2.OscalModels
+
+    // Read the YAML file using os.ReadFile
+    yamlData, err := os.ReadFile(filename)
+    if err != nil {
+        return oscalModels, err
+    }
+
+    // Unmarshal the YAML into the oscalModels struct
+    err = yaml.Unmarshal(yamlData, &oscalModels)
+    if err != nil {
+        return oscalModels, err
+    }
+
+    return oscalModels, nil
+}
+
+
+func countControlIDs(oscalModels oscalTypes_1_1_2.OscalModels) *DetailedReportData {
+    controlIDCounts := make(map[string]int)
+    if oscalModels.ComponentDefinition != nil && oscalModels.ComponentDefinition.Components != nil {
+        for _, component := range *oscalModels.ComponentDefinition.Components {
+            if component.ControlImplementations != nil {
+                for _, controlImpl := range *component.ControlImplementations {
+                    for _, implementedReq := range controlImpl.ImplementedRequirements {
+                        controlID := implementedReq.ControlId
+                        controlIDCounts[controlID]++
+                    }
+                }
+            }
+        }
+    }
+    return &DetailedReportData{ControlIDCounts: controlIDCounts}
+}
+
+func WriteReport(data ReportData, filePath string, format string) error {
+    var err error
+    var fileData []byte
+
+    // Determine the format
+    if format == "yaml" {
+        fileData, err = yaml.Marshal(data)
+        if err != nil {
+            return fmt.Errorf("failed to marshal data to YAML: %v", err)
+        }
+    } else { // default to JSON if not explicitly set to "yaml"
+        fileData, err = json.MarshalIndent(data, "", "  ")
+        if err != nil {
+            return fmt.Errorf("failed to marshal data to JSON: %v", err)
+        }
+    }
+
+    // Write the serialized data to the file
+    err = os.WriteFile(filePath, fileData, 0644)
+    if err != nil {
+        return fmt.Errorf("failed to write file: %v", err)
+    }
+
+    return nil
+}
+
+func PrintReport(data ReportData, format string) error {
+    var err error
+    var fileData []byte
+
+    // Determine the format
+    if format == "yaml" {
+        fileData, err = yaml.Marshal(data)
+        if err != nil {
+            return fmt.Errorf("failed to marshal data to YAML: %v", err)
+        }
+    } else { // default to JSON if not explicitly set to "yaml"
+        fileData, err = json.MarshalIndent(data, "", "  ")
+        if err != nil {
+            return fmt.Errorf("failed to marshal data to JSON: %v", err)
+        }
+    }
+
+    // Write the serialized data to the file
+    fmt.Println(string(fileData))
+
+    return nil
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/defenseunicorns/lula/src/cmd/tools"
 	"github.com/defenseunicorns/lula/src/cmd/validate"
 	"github.com/defenseunicorns/lula/src/cmd/version"
+	"github.com/defenseunicorns/lula/src/cmd/report"
 	"github.com/defenseunicorns/lula/src/config"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 )
@@ -66,6 +67,7 @@ func init() {
 	tools.Include(rootCmd)
 	version.Include(rootCmd)
 	dev.Include(rootCmd)
+	report.Include(rootCmd)
 
 	rootCmd.PersistentFlags().StringVarP(&LogLevelCLI, "log-level", "l", "info", "Log level when running Lula. Valid options are: warn, info, debug, trace")
 }


### PR DESCRIPTION
## Description

Initial POC for report command. Currently only reports controls from component definition. Outputs json by default but also supports yaml. Support the ability to create output file if needed and stdout. This allows for broader use of the report but also ability to send JSON/YAML into a processor for visualization.

Currently can create a detailed and/or summary report based on needs.

## Related Issue

Relates to #223 and #247 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed