### PR TITLE
refactor(validate): validation store/cache

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -14,8 +14,8 @@ import (
 	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/network"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
+	validationstore "github.com/defenseunicorns/lula/src/pkg/common/validation-store"
 	"github.com/defenseunicorns/lula/src/pkg/message"
-	"github.com/defenseunicorns/lula/src/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -135,15 +135,13 @@ func ValidateOnPath(path string) (findingMap map[string]oscalTypes_1_1_2.Finding
 // ValidateOnCompDef takes a single ComponentDefinition object
 // It will perform a validation and add data to a referenced report object
 func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string]oscalTypes_1_1_2.Finding, []oscalTypes_1_1_2.Observation, error) {
-	var backMatterMap map[string]string
-	// Populate a map[uuid]string for back-matter.resources
-	// This is pre-poulated for on-demand use when referencing the back-matter from a link
+	// Create a validation store from the back-matter if it exists
+	var validationStore *validationstore.ValidationStore
 	if compDef.BackMatter != nil {
-		backMatterMap = oscal.BackMatterToMap(*compDef.BackMatter)
+		validationStore = validationstore.NewValidationStoreFromBackMatter(*compDef.BackMatter)
+	} else {
+		validationStore = validationstore.NewValidationStore()
 	}
-
-	// Populate a map for storing validations
-	validationMap := make(types.LulaValidationMap)
 
 	// Loops all the way down
 
@@ -190,7 +188,7 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 						// TODO: potentially use rel to determine the type of validation (Validation Types discussion)
 						rel := strings.Split(link.Rel, ".")
 						if link.Text == "Lula Validation" || rel[0] == "lula" {
-							ids, err := getValidationIds(link, validationMap, backMatterMap)
+							ids, err := getValidationIds(link, validationStore)
 							if err != nil {
 								return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
 							}
@@ -202,7 +200,7 @@ func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string
 									Methods:   []string{"TEST"},
 									UUID:      sharedUuid,
 								}
-								lulaValidation, err := getLulaValidation(id, validationMap, backMatterMap)
+								lulaValidation, err := validationStore.GetLulaValidation(id)
 								if err != nil {
 									return map[string]oscalTypes_1_1_2.Finding{}, []oscalTypes_1_1_2.Observation{}, err
 								}
@@ -350,25 +348,7 @@ func WriteReport(report oscalTypes_1_1_2.AssessmentResults, assessmentFilePath s
 	return nil
 }
 
-func getLulaValidation(id string, validationMap types.LulaValidationMap, backMatterMap map[string]string) (lulaValidation types.LulaValidation, err error) {
-	if lulaValidation, ok := validationMap[id]; ok {
-		return lulaValidation, nil
-	}
-
-	// If the validation is in the backmatter, add it to the map and return
-	if description, ok := backMatterMap[id]; ok {
-		lulaValidation, err = common.ValidationFromString(description)
-		if err != nil {
-			return lulaValidation, err
-		}
-		validationMap[id] = lulaValidation
-		return lulaValidation, nil
-	}
-
-	return lulaValidation, fmt.Errorf("validation #%s not found", id)
-}
-
-func getValidationIds(link oscalTypes_1_1_2.Link, validationMap types.LulaValidationMap, backMatterMap map[string]string) (ids []string, err error) {
+func getValidationIds(link oscalTypes_1_1_2.Link, validationStore *validationstore.ValidationStore) (ids []string, err error) {
 	const WILDCARD = "*"
 	const UUID_PREFIX = "#"
 	const YAML_DELIMITER = "---"
@@ -376,7 +356,7 @@ func getValidationIds(link oscalTypes_1_1_2.Link, validationMap types.LulaValida
 
 	if strings.HasPrefix(link.Href, UUID_PREFIX) {
 		id := strings.TrimPrefix(link.Href, UUID_PREFIX)
-		if _, err := getLulaValidation(id, validationMap, backMatterMap); err != nil {
+		if _, err := validationStore.GetLulaValidation(id); err != nil {
 			return ids, err
 		}
 		return []string{id}, nil
@@ -384,7 +364,7 @@ func getValidationIds(link oscalTypes_1_1_2.Link, validationMap types.LulaValida
 
 	if link.ResourceFragment != WILDCARD && link.ResourceFragment != "" {
 		id := strings.TrimPrefix(link.ResourceFragment, UUID_PREFIX)
-		if _, err := getLulaValidation(id, validationMap, backMatterMap); err == nil {
+		if _, err := validationStore.GetLulaValidation(id); err == nil {
 			return []string{id}, err
 		}
 		ids = append(ids, id)
@@ -415,7 +395,7 @@ func getValidationIds(link oscalTypes_1_1_2.Link, validationMap types.LulaValida
 		if link.ResourceFragment == WILDCARD || isSingleValidation {
 			ids = append(ids, UUID)
 		}
-		validationMap[UUID], err = validation.ToLulaValidation()
+		validationStore.AddValidation(&validation)
 		if err != nil {
 			return ids, err
 		}

--- a/src/pkg/common/validation-store/validation-store.go
+++ b/src/pkg/common/validation-store/validation-store.go
@@ -1,0 +1,75 @@
+package validationstore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	"github.com/defenseunicorns/lula/src/pkg/common"
+	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
+	"github.com/defenseunicorns/lula/src/types"
+)
+
+const UUID_PREFIX = "#"
+const WILD_CARD = "*"
+
+type ValidationStore struct {
+	backMatterMap map[string]string
+	validationMap types.LulaValidationMap
+	fileMap       map[string][]*types.LulaValidation
+}
+
+func NewValidationStore() *ValidationStore {
+	return &ValidationStore{
+		backMatterMap: make(map[string]string),
+		validationMap: make(types.LulaValidationMap),
+		fileMap:       make(map[string][]*types.LulaValidation),
+	}
+}
+
+func NewValidationStoreFromBackMatter(backMatter oscalTypes_1_1_2.BackMatter) *ValidationStore {
+	return &ValidationStore{
+		backMatterMap: oscal.BackMatterToMap(backMatter),
+		validationMap: make(types.LulaValidationMap),
+		fileMap:       make(map[string][]*types.LulaValidation),
+	}
+}
+
+func (v *ValidationStore) AddValidation(validation *common.Validation) (id string, err error) {
+	if validation.Metadata.UUID == "" {
+		validation.Metadata.UUID = uuid.NewUUID()
+	}
+
+	v.validationMap[validation.Metadata.UUID], err = validation.ToLulaValidation()
+
+	if err != nil {
+		return "", err
+	}
+
+	return validation.Metadata.UUID, nil
+
+}
+
+func (v *ValidationStore) GetLulaValidation(id string) (validation *types.LulaValidation, err error) {
+	trimmedId := trimIdPrefix(id)
+
+	if validation, ok := v.validationMap[trimmedId]; ok {
+		return &validation, nil
+	}
+
+	if validationString, ok := v.backMatterMap[trimmedId]; ok {
+		lulaValidation, err := common.ValidationFromString(validationString)
+		if err != nil {
+			return nil, err
+		}
+		v.validationMap[trimmedId] = lulaValidation
+		return &lulaValidation, nil
+	}
+
+	return validation, fmt.Errorf("validation #%s not found", trimmedId)
+}
+
+func trimIdPrefix(id string) string {
+	return strings.TrimPrefix(id, UUID_PREFIX)
+}

--- a/src/pkg/common/validation-store/validation-store.go
+++ b/src/pkg/common/validation-store/validation-store.go
@@ -1,18 +1,21 @@
 package validationstore
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/pkg/common"
+	"github.com/defenseunicorns/lula/src/pkg/common/network"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/types"
 )
 
 const UUID_PREFIX = "#"
 const WILDCARD = "*"
+const YAML_DELIMITER = "---"
 
 type ValidationStore struct {
 	backMatterMap map[string]string
@@ -87,8 +90,78 @@ func (v *ValidationStore) GetHrefIds(href string) (ids []string, err error) {
 	return nil, fmt.Errorf("href #%s not found", href)
 }
 
-// TrimIdPrefix trims the id prefix from the given id
+// AddFromLink adds a validation from a link
+func (v *ValidationStore) AddFromLink(link oscalTypes_1_1_2.Link) (ids []string, err error) {
+	id := link.Href
 
+	// If the resource fragment is not a wildcard, trim the prefix from the resource fragment
+	if link.ResourceFragment != WILDCARD && link.ResourceFragment != "" {
+		id = TrimIdPrefix(link.ResourceFragment)
+	}
+
+	// If the id is a uuid and the lula validation exists, return the id
+	if _, err := v.GetLulaValidation(id); err == nil {
+		return []string{id}, err
+	}
+
+	// If the id is a url and has been fetched before, return the ids
+	if ids, err := v.GetHrefIds(id); err == nil {
+		return ids, nil
+	}
+
+	// If the id is a url and has not been fetched before, fetch and add to the store
+	ids, err = v.fetchFromRemoteLink(link)
+	if err != nil {
+		return ids, err
+	}
+
+	return ids, nil
+}
+
+// fetchFromRemoteLink adds a validation from a remote source
+func (v *ValidationStore) fetchFromRemoteLink(link oscalTypes_1_1_2.Link) (ids []string, err error) {
+	wantedId := TrimIdPrefix(link.ResourceFragment)
+
+	validationBytes, err := network.Fetch(link.Href)
+	if err != nil {
+		return ids, err
+	}
+
+	validationBytesArr := bytes.Split(validationBytes, []byte(YAML_DELIMITER))
+	isSingleValidation := len(validationBytesArr) == 1
+
+	for _, validationBytes := range validationBytesArr {
+		var validation common.Validation
+		if err = validation.UnmarshalYaml(validationBytes); err != nil {
+			return ids, err
+		}
+		// If the validation does not have a UUID, create a new one
+		if validation.Metadata.UUID == "" {
+			validation.Metadata.UUID = uuid.NewUUID()
+		}
+
+		// Add the validation to the store
+		id, err := v.AddValidation(&validation)
+		if err != nil {
+			return ids, err
+		}
+
+		// If the wanted id is the id, the id is a wildcard, or there is only one validation, add the id to the ids
+		if wantedId == id || wantedId == WILDCARD || isSingleValidation {
+			ids = append(ids, id)
+		}
+	}
+
+	if len(ids) == 0 {
+		return ids, fmt.Errorf("no validations found for %s", link.Href)
+	} else {
+		v.SetHrefIds(link.Href, ids)
+	}
+
+	return ids, nil
+}
+
+// TrimIdPrefix trims the id prefix from the given id
 func TrimIdPrefix(id string) string {
 	return strings.TrimPrefix(id, UUID_PREFIX)
 }

--- a/src/pkg/common/validation-store/validation-store.go
+++ b/src/pkg/common/validation-store/validation-store.go
@@ -12,30 +12,33 @@ import (
 )
 
 const UUID_PREFIX = "#"
-const WILD_CARD = "*"
+const WILDCARD = "*"
 
 type ValidationStore struct {
 	backMatterMap map[string]string
 	validationMap types.LulaValidationMap
-	fileMap       map[string][]*types.LulaValidation
+	hrefIdMap     map[string][]string
 }
 
+// NewValidationStore creates a new validation store
 func NewValidationStore() *ValidationStore {
 	return &ValidationStore{
 		backMatterMap: make(map[string]string),
 		validationMap: make(types.LulaValidationMap),
-		fileMap:       make(map[string][]*types.LulaValidation),
+		hrefIdMap:     make(map[string][]string),
 	}
 }
 
+// NewValidationStoreFromBackMatter creates a new validation store from a back matter
 func NewValidationStoreFromBackMatter(backMatter oscalTypes_1_1_2.BackMatter) *ValidationStore {
 	return &ValidationStore{
 		backMatterMap: oscal.BackMatterToMap(backMatter),
 		validationMap: make(types.LulaValidationMap),
-		fileMap:       make(map[string][]*types.LulaValidation),
+		hrefIdMap:     make(map[string][]string),
 	}
 }
 
+// AddValidation adds a validation to the store
 func (v *ValidationStore) AddValidation(validation *common.Validation) (id string, err error) {
 	if validation.Metadata.UUID == "" {
 		validation.Metadata.UUID = uuid.NewUUID()
@@ -51,8 +54,9 @@ func (v *ValidationStore) AddValidation(validation *common.Validation) (id strin
 
 }
 
+// GetLulaValidation gets the LulaValidation from the store
 func (v *ValidationStore) GetLulaValidation(id string) (validation *types.LulaValidation, err error) {
-	trimmedId := trimIdPrefix(id)
+	trimmedId := TrimIdPrefix(id)
 
 	if validation, ok := v.validationMap[trimmedId]; ok {
 		return &validation, nil
@@ -70,6 +74,21 @@ func (v *ValidationStore) GetLulaValidation(id string) (validation *types.LulaVa
 	return validation, fmt.Errorf("validation #%s not found", trimmedId)
 }
 
-func trimIdPrefix(id string) string {
+// SetHrefIds sets the validation ids for a given href
+func (v *ValidationStore) SetHrefIds(href string, ids []string) {
+	v.hrefIdMap[href] = ids
+}
+
+// GetHrefIds gets the validation ids for a given href
+func (v *ValidationStore) GetHrefIds(href string) (ids []string, err error) {
+	if ids, ok := v.hrefIdMap[href]; ok {
+		return ids, nil
+	}
+	return nil, fmt.Errorf("href #%s not found", href)
+}
+
+// TrimIdPrefix trims the id prefix from the given id
+
+func TrimIdPrefix(id string) string {
 	return strings.TrimPrefix(id, UUID_PREFIX)
 }

--- a/src/pkg/common/validation-store/validation-store_test.go
+++ b/src/pkg/common/validation-store/validation-store_test.go
@@ -8,6 +8,24 @@ import (
 	validationstore "github.com/defenseunicorns/lula/src/pkg/common/validation-store"
 )
 
+const (
+	validationPath = "../../../test/e2e/scenarios/remote-validations/validation.opa.yaml"
+	componentPath  = "../../../test/e2e/scenarios/remote-validations/component-definition.yaml"
+)
+
+func generateValidation(t *testing.T) common.Validation {
+	validationBytes, err := common.ReadFileToBytes(validationPath)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	var validation common.Validation
+	err = validation.UnmarshalYaml(validationBytes)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	return validation
+}
+
 func TestNewValidationStore(t *testing.T) {
 	v := validationstore.NewValidationStore()
 	if v == nil {
@@ -49,16 +67,68 @@ func TestGetLulaValidation(t *testing.T) {
 	}
 }
 
-func generateValidation(t *testing.T) common.Validation {
-	validationPath := "../../../test/e2e/scenarios/remote-validations/validation.opa.yaml"
-	validationBytes, err := common.ReadFileToBytes(validationPath)
-	if err != nil {
-		t.Errorf("Expected no error, but got %v", err)
+func TestValidationStore_AddFromLink(t *testing.T) {
+	tests := []struct {
+		name    string
+		link    oscalTypes_1_1_2.Link
+		numIds  int
+		wantErr bool
+	}{
+		{
+			name: "multi-remote-validations: wildcard",
+			link: oscalTypes_1_1_2.Link{
+				Href:             "file://../../../../test/e2e/scenarios/remote-validations/multi-validations.yaml",
+				ResourceFragment: "*",
+			},
+			numIds:  2,
+			wantErr: false,
+		},
+		{
+			name: "one from multi-remote-validation",
+			link: oscalTypes_1_1_2.Link{
+				Href:             "file://../../../../test/e2e/scenarios/remote-validations/multi-validations.yaml",
+				ResourceFragment: "9d09b4fc-1a82-4434-9fbe-392935347a84",
+			},
+			numIds:  1,
+			wantErr: false,
+		},
+		{
+			name: "single validation",
+			link: oscalTypes_1_1_2.Link{
+				Href: "file://../../../../test/e2e/scenarios/remote-validations/validation.opa.yaml",
+			},
+			numIds:  1,
+			wantErr: false,
+		},
+		{
+			name: "invalid link",
+			link: oscalTypes_1_1_2.Link{
+				Href: "file://../../../../test/e2e/scenarios/remote-validations/invalid-link.opa.yaml",
+			},
+			numIds:  0,
+			wantErr: true,
+		},
+		{
+			name: "invalid resource fragment",
+			link: oscalTypes_1_1_2.Link{
+				Href:             "file://../../../../test/e2e/scenarios/remote-validations/multi-validations.yaml",
+				ResourceFragment: "invalid-resource-fragment",
+			},
+			numIds:  0,
+			wantErr: true,
+		},
 	}
-	var validation common.Validation
-	err = validation.UnmarshalYaml(validationBytes)
-	if err != nil {
-		t.Errorf("Expected no error, but got %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := validationstore.NewValidationStore()
+			gotIds, err := v.AddFromLink(tt.link)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidationStore.AddFromLink() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(gotIds) != tt.numIds {
+				t.Errorf("ValidationStore.AddFromLink() = %v ids, want %v ids", len(gotIds), tt.numIds)
+			}
+		})
 	}
-	return validation
 }

--- a/src/pkg/common/validation-store/validation-store_test.go
+++ b/src/pkg/common/validation-store/validation-store_test.go
@@ -1,0 +1,64 @@
+package validationstore_test
+
+import (
+	"testing"
+
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	"github.com/defenseunicorns/lula/src/pkg/common"
+	validationstore "github.com/defenseunicorns/lula/src/pkg/common/validation-store"
+)
+
+func TestNewValidationStore(t *testing.T) {
+	v := validationstore.NewValidationStore()
+	if v == nil {
+		t.Error("Expected a new ValidationStore, but got nil")
+	}
+}
+
+func TestNewValidationStoreFromBackMatter(t *testing.T) {
+	backMatter := oscalTypes_1_1_2.BackMatter{}
+	v := validationstore.NewValidationStoreFromBackMatter(backMatter)
+	if v == nil {
+		t.Error("Expected a new ValidationStore from back matter, but got nil")
+	}
+}
+
+func TestAddValidation(t *testing.T) {
+	validation := generateValidation(t)
+	v := validationstore.NewValidationStore()
+
+	id, err := v.AddValidation(&validation)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	if id == "" {
+		t.Error("Expected a non-empty ID, but got an empty string")
+	}
+}
+
+func TestGetLulaValidation(t *testing.T) {
+	validation := generateValidation(t)
+	v := validationstore.NewValidationStore()
+	id, _ := v.AddValidation(&validation)
+	lulaValidation, err := v.GetLulaValidation(id)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	if lulaValidation == nil {
+		t.Error("Expected a LulaValidation, but got nil")
+	}
+}
+
+func generateValidation(t *testing.T) common.Validation {
+	validationPath := "../../../test/e2e/scenarios/remote-validations/validation.opa.yaml"
+	validationBytes, err := common.ReadFileToBytes(validationPath)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	var validation common.Validation
+	err = validation.UnmarshalYaml(validationBytes)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	return validation
+}


### PR DESCRIPTION
## Description
- extract backmatter and validation maps into `ValidationStore`
- create methods for adding and retrieving validations from the `ValidationStore`
- extract getValidationIds from validate to validationstore as AddFromLink and fetchFromRemoteLink
...

## Related Issue
#369 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed