### PR TITLE
Dev validate with optional resources file input

### DIFF
--- a/src/test/e2e/dev_validation_test.go
+++ b/src/test/e2e/dev_validation_test.go
@@ -40,12 +40,13 @@ func TestDevValidation(t *testing.T) {
 
 			message.NoProgress = true
 
+			var resourcesBytes []byte
 			validationBytes, err := common.ReadFileToBytes(validationFile)
 			if err != nil {
 				t.Errorf("Error reading file: %v", err)
 			}
 
-			validation, err := dev.DevValidate(ctx, validationBytes)
+			validation, err := dev.DevValidate(ctx, validationBytes, resourcesBytes)
 			if err != nil {
 				t.Errorf("Error testing dev validate: %v", err)
 			}
@@ -68,12 +69,13 @@ func TestDevValidation(t *testing.T) {
 
 			message.NoProgress = true
 
+			var resourcesBytes []byte
 			validationBytes, err := common.ReadFileToBytes(validationFile)
 			if err != nil {
 				t.Errorf("Error reading file: %v", err)
 			}
 
-			validation, err := dev.DevValidate(ctx, validationBytes)
+			validation, err := dev.DevValidate(ctx, validationBytes, resourcesBytes)
 			if err != nil {
 				t.Errorf("Error testing dev validate: %v", err)
 			}
@@ -87,7 +89,43 @@ func TestDevValidation(t *testing.T) {
 				t.Errorf("Validation failed")
 			}
 
-			message.Infof("Successfully validated dev validate comman with kyverno")
+			message.Infof("Successfully validated dev validate command with kyverno")
+
+			return ctx
+		}).
+		Assess("Validate with resources", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+			validationFile := "./scenarios/dev-validate/validation.yaml"
+			resourcesFile := "./scenarios/dev-validate/resources.foo-baz.json"
+			expectedResult := false
+
+			message.NoProgress = true
+
+			resourcesBytes, err := common.ReadFileToBytes(resourcesFile)
+			if err != nil {
+				t.Errorf("Error reading file: %v", err)
+			}
+			validationBytes, err := common.ReadFileToBytes(validationFile)
+			if err != nil {
+				t.Errorf("Error reading file: %v", err)
+			}
+
+			validation, err := dev.DevValidate(ctx, validationBytes, resourcesBytes)
+			if err != nil {
+				t.Errorf("Error testing dev validate: %v", err)
+			}
+
+			// Check the validation result has been evaluated
+			if !validation.Evaluated {
+				t.Errorf("Validation result has not been evaluated")
+			}
+
+			result := validation.Result.Failing == 0
+			// If the expected result is not equal to the actual result, return an error
+			if expectedResult != result {
+				t.Errorf("expected result to be %t got %t", expectedResult, result)
+			}
+
+			message.Infof("Successfully validated dev validate command with resources")
 
 			return ctx
 		}).

--- a/src/test/e2e/scenarios/dev-validate/resources.foo-baz.json
+++ b/src/test/e2e/scenarios/dev-validate/resources.foo-baz.json
@@ -1,0 +1,160 @@
+{
+  "podsvt": [
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar\"},\"name\":\"test-dev-validation-pod\",\"namespace\":\"validation-test\"},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"pods-simple-container\"}]}}\n"
+        },
+        "creationTimestamp": "2024-04-26T13:32:22Z",
+        "labels": {
+          "foo": "baz"
+        },
+        "name": "test-dev-validation-pod",
+        "namespace": "validation-test",
+        "resourceVersion": "708",
+        "uid": "555d8f44-7cf6-4236-9c6d-e53078292835"
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "nginx",
+            "imagePullPolicy": "Always",
+            "name": "pods-simple-container",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "kube-api-access-qmbvt",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "nodeName": "k3d-lula-test-server-0",
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+          {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+          },
+          {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+          }
+        ],
+        "volumes": [
+          {
+            "name": "kube-api-access-qmbvt",
+            "projected": {
+              "defaultMode": 420,
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ],
+                    "name": "kube-root-ca.crt"
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        },
+                        "path": "namespace"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2024-04-26T13:32:22Z",
+            "status": "True",
+            "type": "Initialized"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2024-04-26T13:32:27Z",
+            "status": "True",
+            "type": "Ready"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2024-04-26T13:32:27Z",
+            "status": "True",
+            "type": "ContainersReady"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2024-04-26T13:32:22Z",
+            "status": "True",
+            "type": "PodScheduled"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "containerID": "containerd://a3391ee33386bbe625e651a247cb430fca22815a4f0a6220081c5a559c09a37f",
+            "image": "docker.io/library/nginx:latest",
+            "imageID": "docker.io/library/nginx@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee",
+            "lastState": {},
+            "name": "pods-simple-container",
+            "ready": true,
+            "restartCount": 0,
+            "started": true,
+            "state": {
+              "running": {
+                "startedAt": "2024-04-26T13:32:26Z"
+              }
+            }
+          }
+        ],
+        "hostIP": "172.23.0.3",
+        "phase": "Running",
+        "podIP": "10.42.0.9",
+        "podIPs": [
+          {
+            "ip": "10.42.0.9"
+          }
+        ],
+        "qosClass": "BestEffort",
+        "startTime": "2024-04-26T13:32:22Z"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Added optional -r or --resources-file with expected input of *.json file. This will pass the resources to the validate function as an option to use those "static" resources vs the runtime "dynamic" ones pulled by the domain function GetResources.

Figured if other options were desired for the "Validate" function, those could be extended in the `lulaValidationOptions`

## Related Issue

Relates to #385 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed