### PR TITLE
Added Observation logging to dev validate

### DIFF
--- a/src/cmd/dev/validate.go
+++ b/src/cmd/dev/validate.go
@@ -125,6 +125,14 @@ func init() {
 			}
 			// Print the number of passing and failing results
 			message.Infof("Validation completed with %d passing and %d failing results", validation.Result.Passing, validation.Result.Failing)
+
+			// Print observations if there are any
+			if len(validation.Result.Observations) > 0 {
+				message.Infof("Observations:")
+				for key, observation := range validation.Result.Observations {
+					message.Infof("--> %s: %s", key, observation)
+				}
+			}
 		},
 	}
 

--- a/src/cmd/dev/validate.go
+++ b/src/cmd/dev/validate.go
@@ -118,14 +118,6 @@ func init() {
 				message.Fatalf(err, "error writing result: %v", err)
 			}
 
-			result := validation.Result.Failing == 0
-			// If the expected result is not equal to the actual result, return an error
-			if validateOpts.ExpectedResult != result {
-				message.Fatalf(fmt.Errorf("validation failed"), "expected result to be %t got %t", validateOpts.ExpectedResult, result)
-			}
-			// Print the number of passing and failing results
-			message.Infof("Validation completed with %d passing and %d failing results", validation.Result.Passing, validation.Result.Failing)
-
 			// Print observations if there are any
 			if len(validation.Result.Observations) > 0 {
 				message.Infof("Observations:")
@@ -133,6 +125,14 @@ func init() {
 					message.Infof("--> %s: %s", key, observation)
 				}
 			}
+
+			result := validation.Result.Failing == 0
+			// If the expected result is not equal to the actual result, return an error
+			if validateOpts.ExpectedResult != result {
+				message.Fatalf(fmt.Errorf("validation failed"), "expected result to be %t got %t", validateOpts.ExpectedResult, result)
+			}
+			// Print the number of passing and failing results
+			message.Infof("Validation completed with %d passing and %d failing results", validation.Result.Passing, validation.Result.Failing)
 		},
 	}
 


### PR DESCRIPTION
## Description

Added print statement for observations to support debugging validation files - quick update to add observation logging.

Unsure if there's a better formatting option to indent, tried a couple things and the messages seemed to scrub any extra spacing so went with `-->` prefix to the observation results.

## Related Issue

Relates to #390 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed