### PR TITLE
feat(oscal): merge on write consolidation

### DIFF
--- a/src/cmd/generate/generate.go
+++ b/src/cmd/generate/generate.go
@@ -1,18 +1,14 @@
 package generate
 
 import (
-	"bytes"
 	"fmt"
-	"os"
 
-	gooscalUtils "github.com/defenseunicorns/go-oscal/src/pkg/utils"
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/network"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/spf13/cobra"
-
-	"gopkg.in/yaml.v3"
 )
 
 type flags struct {
@@ -68,7 +64,6 @@ var generateComponentCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, args []string) {
 		var remarks []string
 		var title = "Component Title"
-		var outputFile = "oscal-component.yaml"
 		// check for Catalog Source - this field is required
 		if componentOpts.CatalogSource == "" {
 			message.Fatal(fmt.Errorf("no catalog source provided"), "generate component requires a catalog input source")
@@ -106,50 +101,14 @@ var generateComponentCmd = &cobra.Command{
 			message.Fatalf(fmt.Errorf("error creating component"), "error creating component")
 		}
 
-		var fileName string
-		if opts.OutputFile != "" {
-			fileName = opts.OutputFile
-		} else {
-			fileName = "oscal-component.yaml"
+		var model = oscalTypes_1_1_2.OscalModels{
+			ComponentDefinition: comp,
 		}
 
-		if componentOpts.OutputFile != "" {
-			outputFile = componentOpts.OutputFile
-		}
-		// Check for an existing file
-		if _, err := os.Stat(outputFile); err == nil {
-			existingFileBytes, err := os.ReadFile(outputFile)
-			if err != nil {
-				message.Fatalf(fmt.Errorf("error reading existing file"), "error reading existing file")
-			}
-			// Create new component definition object
-			existingComponent, err := oscal.NewOscalComponentDefinition(outputFile, existingFileBytes)
-			if err != nil {
-				message.Fatalf(fmt.Errorf("error creating new component definition"), "error creating new component definition")
-			}
-			// Merge the newly generated document into the existing document
-			comp, err = oscal.MergeComponentDefinitions(existingComponent, comp)
-			if err != nil {
-				message.Fatalf(fmt.Errorf("error merging component definition on component"), "error merging component definition on component")
-			}
-			comp.Metadata.LastModified = gooscalUtils.GetTimestamp()
-		}
-
-		var b bytes.Buffer
-
-		var component = oscalTypes_1_1_2.OscalModels{
-			ComponentDefinition: &comp,
-		}
-
-		yamlEncoder := yaml.NewEncoder(&b)
-		yamlEncoder.SetIndent(2)
-		yamlEncoder.Encode(component)
-
-		message.Infof("Writing Component Definition to: %s", fileName)
-
-		err = os.WriteFile(fileName, b.Bytes(), 0644)
+		// Write the component definition to file
+		err = common.WriteFile(componentOpts.OutputFile, &model)
 		if err != nil {
-			message.Fatalf(fmt.Errorf("error writing Component Definition to: %s", fileName), "error writing Component Definition to: %s", fileName)
+			message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
 		}
 
 	},

--- a/src/cmd/generate/generate.go
+++ b/src/cmd/generate/generate.go
@@ -108,7 +108,7 @@ var generateComponentCmd = &cobra.Command{
 		// Write the component definition to file
 		err = common.WriteFile(componentOpts.OutputFile, &model)
 		if err != nil {
-			message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
+			message.Fatalf(err, "error writing component to file")
 		}
 
 	},

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -19,8 +19,8 @@ import (
 )
 
 type flags struct {
-	AssessmentFile string // -a --assessment-file
-	InputFile      string // -f --input-file
+	OutputFile string // -o --output-file
+	InputFile  string // -f --input-file
 }
 
 var opts = &flags{}
@@ -54,10 +54,14 @@ var validateCmd = &cobra.Command{
 			message.Fatalf(err, "Generate error")
 		}
 
-		// Write report(s) to file
-		err = WriteReport(report, opts.AssessmentFile)
-		if err != nil {
-			message.Fatalf(err, "Write error")
+		var model = oscalTypes_1_1_2.OscalModels{
+			AssessmentResults: report,
+		}
+
+		// Write the component definition to file
+		err = common.WriteFile(opts.OutputFile, &model)
+		if err == nil {
+			message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
 		}
 	},
 }
@@ -65,7 +69,7 @@ var validateCmd = &cobra.Command{
 func ValidateCommand() *cobra.Command {
 
 	// insert flag options here
-	validateCmd.Flags().StringVarP(&opts.AssessmentFile, "assessment-file", "a", "", "the path to write assessment results. Creates a new file or appends to existing files")
+	validateCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "o", "", "the path to write assessment results. Creates a new file or appends to existing files")
 	validateCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to the target OSCAL component definition")
 	return validateCmd
 }
@@ -132,7 +136,7 @@ func ValidateOnPath(path string) (findingMap map[string]oscalTypes_1_1_2.Finding
 
 // ValidateOnCompDef takes a single ComponentDefinition object
 // It will perform a validation and add data to a referenced report object
-func ValidateOnCompDef(compDef oscalTypes_1_1_2.ComponentDefinition) (map[string]oscalTypes_1_1_2.Finding, []oscalTypes_1_1_2.Observation, error) {
+func ValidateOnCompDef(compDef *oscalTypes_1_1_2.ComponentDefinition) (map[string]oscalTypes_1_1_2.Finding, []oscalTypes_1_1_2.Observation, error) {
 	// Create a validation store from the back-matter if it exists
 	var validationStore *validationstore.ValidationStore
 	if compDef.BackMatter != nil {

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -30,7 +30,7 @@ To validate on a cluster:
 	lula validate -f ./oscal-component.yaml
 
 To indicate a specific Assessment Results file to create or append to:
-	lula validate -f ./oscal-component.yaml -a assessment-results.yaml
+	lula validate -f ./oscal-component.yaml -o assessment-results.yaml
 `
 
 var validateCmd = &cobra.Command{
@@ -60,7 +60,7 @@ var validateCmd = &cobra.Command{
 
 		// Write the component definition to file
 		err = common.WriteFile(opts.OutputFile, &model)
-		if err == nil {
+		if err != nil {
 			message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
 		}
 	},

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -61,7 +61,7 @@ var validateCmd = &cobra.Command{
 		// Write the component definition to file
 		err = common.WriteFile(opts.OutputFile, &model)
 		if err != nil {
-			message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
+			message.Fatalf(err, "error writing component to file")
 		}
 	},
 }

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -62,7 +62,7 @@ func ReadFileToBytes(path string) ([]byte, error) {
 func WriteFile(filePath string, model *oscalTypes_1_1_2.OscalModels) error {
 
 	// if no path or directory add default filename
-	if filePath == "" {
+	if filepath.Ext(filePath) == "" {
 		filePath = filepath.Join(filePath, "oscal.yaml")
 	}
 

--- a/src/pkg/common/common.go
+++ b/src/pkg/common/common.go
@@ -62,7 +62,7 @@ func ReadFileToBytes(path string) ([]byte, error) {
 func WriteFile(filePath string, model *oscalTypes_1_1_2.OscalModels) error {
 
 	// if no path or directory add default filename
-	if filepath.Ext(filePath) == "" {
+	if filePath == "" {
 		filePath = filepath.Join(filePath, "oscal.yaml")
 	}
 

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -24,8 +24,8 @@ func NewAssessmentResults(data []byte) (oscalTypes_1_1_2.AssessmentResults, erro
 	return *oscalModels.AssessmentResults, nil
 }
 
-func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, observations []oscalTypes_1_1_2.Observation) (oscalTypes_1_1_2.AssessmentResults, error) {
-	var assessmentResults oscalTypes_1_1_2.AssessmentResults
+func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, observations []oscalTypes_1_1_2.Observation) (*oscalTypes_1_1_2.AssessmentResults, error) {
+	var assessmentResults = &oscalTypes_1_1_2.AssessmentResults{}
 
 	// Single time used for all time related fields
 	rfc3339Time := time.Now()
@@ -78,6 +78,19 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, o
 	}
 
 	return assessmentResults, nil
+}
+
+func MergeAssessmentResults(original *oscalTypes_1_1_2.AssessmentResults, latest *oscalTypes_1_1_2.AssessmentResults) (*oscalTypes_1_1_2.AssessmentResults, error) {
+
+	results := make([]oscalTypes_1_1_2.Result, 0)
+	// append new results first - unfurl so as to allow multiple results in the future
+	results = append(results, original.Results...)
+	results = append(results, latest.Results...)
+	original.Results = results
+
+	original.Metadata.LastModified = time.Now()
+
+	return original, nil
 }
 
 func GenerateFindingsMap(findings []oscalTypes_1_1_2.Finding) map[string]oscalTypes_1_1_2.Finding {

--- a/src/pkg/common/oscal/complete-schema.go
+++ b/src/pkg/common/oscal/complete-schema.go
@@ -13,3 +13,10 @@ func NewOscalModel(data []byte) (*oscalTypes_1_1_2.OscalModels, error) {
 	}
 	return &oscalModel, nil
 }
+
+func MergeOscalModels(existingModel *oscalTypes_1_1_2.OscalModels, model *oscalTypes_1_1_2.OscalModels) (*oscalTypes_1_1_2.OscalModels, error) {
+
+	// Now to check each model type - currently only component definition and assessment-results apply
+
+	return existingModel, nil
+}

--- a/src/pkg/common/oscal/complete-schema.go
+++ b/src/pkg/common/oscal/complete-schema.go
@@ -14,9 +14,33 @@ func NewOscalModel(data []byte) (*oscalTypes_1_1_2.OscalModels, error) {
 	return &oscalModel, nil
 }
 
-func MergeOscalModels(existingModel *oscalTypes_1_1_2.OscalModels, model *oscalTypes_1_1_2.OscalModels) (*oscalTypes_1_1_2.OscalModels, error) {
-
+func MergeOscalModels(existingModel *oscalTypes_1_1_2.OscalModels, newModel *oscalTypes_1_1_2.OscalModels) (*oscalTypes_1_1_2.OscalModels, error) {
+	var err error
 	// Now to check each model type - currently only component definition and assessment-results apply
 
-	return existingModel, nil
+	// Component definition
+	if existingModel.ComponentDefinition != nil && newModel.ComponentDefinition != nil {
+		merged, err := MergeComponentDefinitions(existingModel.ComponentDefinition, newModel.ComponentDefinition)
+		if err != nil {
+			return nil, err
+		}
+		// Re-assign after processing errors
+		existingModel.ComponentDefinition = merged
+	} else if existingModel.ComponentDefinition == nil && newModel.ComponentDefinition != nil {
+		existingModel.ComponentDefinition = newModel.ComponentDefinition
+	}
+
+	// Assessment Results
+	if existingModel.AssessmentResults != nil && newModel.AssessmentResults != nil {
+		merged, err := MergeAssessmentResults(existingModel.AssessmentResults, newModel.AssessmentResults)
+		if err != nil {
+			return existingModel, err
+		}
+		// Re-assign after processing errors
+		existingModel.AssessmentResults = merged
+	} else if existingModel.AssessmentResults == nil && newModel.AssessmentResults != nil {
+		existingModel.AssessmentResults = newModel.AssessmentResults
+	}
+
+	return existingModel, err
 }

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -153,7 +152,7 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 	// Write the component definition to file
 	err = common.WriteFile("sar-test.yaml", &model)
 	if err != nil {
-		message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
+		message.Fatalf(err, "error writing component to file")
 	}
 
 	initialResultCount := len(report.Results)
@@ -170,7 +169,7 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 	// Write the component definition to file
 	err = common.WriteFile("sar-test.yaml", &model)
 	if err != nil {
-		message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
+		message.Fatalf(err, "error writing component to file")
 	}
 
 	data, err := os.ReadFile("sar-test.yaml")

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -2,13 +2,16 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/revision"
 	"github.com/defenseunicorns/go-oscal/src/pkg/validation"
+	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/cmd/validate"
+	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/defenseunicorns/lula/src/test/util"
@@ -143,10 +146,14 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 		t.Fatal("Failed generation of Assessment Results object with: ", err)
 	}
 
-	// Write report(s) to file
-	err = validate.WriteReport(report, "sar-test.yaml")
+	var model = oscalTypes_1_1_2.OscalModels{
+		AssessmentResults: report,
+	}
+
+	// Write the component definition to file
+	err = common.WriteFile("sar-test.yaml", &model)
 	if err != nil {
-		t.Fatal("Failed to write report to file: ", err)
+		message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
 	}
 
 	initialResultCount := len(report.Results)
@@ -156,11 +163,14 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 	if err != nil {
 		t.Fatal("Failed generation of Assessment Results object with: ", err)
 	}
+	model = oscalTypes_1_1_2.OscalModels{
+		AssessmentResults: report,
+	}
 
-	// Write report(s) to file
-	err = validate.WriteReport(report, "sar-test.yaml")
+	// Write the component definition to file
+	err = common.WriteFile("sar-test.yaml", &model)
 	if err != nil {
-		t.Fatal("Failed to write report to file: ", err)
+		message.Fatalf(fmt.Errorf("error writing component to file"), "error writing component to file")
 	}
 
 	data, err := os.ReadFile("sar-test.yaml")

--- a/src/test/e2e/validation_composition_test.go
+++ b/src/test/e2e/validation_composition_test.go
@@ -80,7 +80,7 @@ func TestValidationComposition(t *testing.T) {
 				t.Error(err)
 			}
 
-			findings, observations, err = validate.ValidateOnCompDef(*oscalModel.ComponentDefinition)
+			findings, observations, err = validate.ValidateOnCompDef(oscalModel.ComponentDefinition)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
## Description
Common write functionality that should provide consolidation for writing any OSCAL objects to a file. 

## Discussion
Open to feedback or discussion here. Having the ability to aggregate many oscal models into a single artifact will allow for greater portability and less bloat across the OSCAL lifecycle. Something like a production environment would have used most of the models - requiring one file for each may not be optimal. 

Yes - this has the potential to create large files that are not visually appealing. This is more of an opt-in process based on the output file specified. I'd also argue that machine-readable files are just that - machine-readable - and it will be Lulas job to make the underlying data accessible.

## Related Issue

Closes #402 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed