### PR TITLE
chore(renovate): update config to handle conventional commit titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,25 +1,44 @@
 {
-  "extends": ["config:base"],
-  "ignorePaths": ["**/adr/**", "**/docs/**", "**/test/**"],
+  "extends": [
+    "config:base",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "ignorePaths": [
+    "**/adr/**",
+    "**/docs/**",
+    "**/test/**"
+  ],
   "timezone": "America/New_York",
-  "schedule": ["after 12pm and before 11am every weekday"],
+  "schedule": [
+    "after 12pm and before 11am every weekday"
+  ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true,
       "automergeType": "pr"
     },
     {
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
       "automerge": true,
       "automergeType": "pr"
     }
   ],
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
   "platformAutomerge": true,
   "platformCommit": true,
-  "postUpdateOptions": ["gomodTidy"],
-  "commitBodyTable": true,
-  "commitMessagePrefix": "deps"
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "commitBodyTable": true
 }


### PR DESCRIPTION
## Description

- fix renovate config to use conventional messages. 
- should fix current pr titles failing

## Related Issue

#427 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed