### PR TITLE
fix(validate): fix order of assessment-results results

### DIFF
--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -89,9 +89,9 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, o
 func MergeAssessmentResults(original *oscalTypes_1_1_2.AssessmentResults, latest *oscalTypes_1_1_2.AssessmentResults) (*oscalTypes_1_1_2.AssessmentResults, error) {
 
 	results := make([]oscalTypes_1_1_2.Result, 0)
-	// append new results first - unfurl so as to allow multiple results in the future
-	results = append(results, original.Results...)
+	// append newest to oldest results
 	results = append(results, latest.Results...)
+	results = append(results, original.Results...)
 	original.Results = results
 
 	original.Metadata.LastModified = time.Now()

--- a/src/test/e2e/pod_validation_test.go
+++ b/src/test/e2e/pod_validation_test.go
@@ -180,7 +180,7 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 		AssessmentResults: report,
 	}
 
-	// Write the component definition to file
+	// Write the assessment results to file
 	err = oscal.WriteOscalModel("sar-test.yaml", &model)
 	if err != nil {
 		message.Fatalf(err, "error writing component to file")
@@ -193,11 +193,15 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 	if err != nil {
 		t.Fatal("Failed generation of Assessment Results object with: ", err)
 	}
+
+	// Get the UUID of the report results - there should only be one
+	resultId := report.Results[0].UUID
+
 	model = oscalTypes_1_1_2.OscalModels{
 		AssessmentResults: report,
 	}
 
-	// Write the component definition to file
+	// Write the assessment results to file
 	err = oscal.WriteOscalModel("sar-test.yaml", &model)
 	if err != nil {
 		message.Fatalf(err, "error writing component to file")
@@ -216,6 +220,10 @@ func validatePodLabelPass(ctx context.Context, t *testing.T, config *envconf.Con
 	// The number of results in the file should be more than initially
 	if len(tempAssessment.Results) <= initialResultCount {
 		t.Fatal("Failed to append results to existing report")
+	}
+
+	if resultId != tempAssessment.Results[0].UUID {
+		t.Fatal("Failed to prepend results to existing report")
 	}
 
 	validatorResponse, err := validation.ValidationCommand("sar-test.yaml")


### PR DESCRIPTION
## Description

`lula evaluate` to a single file assumes that the latest results are being prepended to the array of results. For now this means we need to put the append latest results before original. Updated test to reflect the order required.

Will file an issue surrounding how Lula will identify a threshold that is not the second result in the array (current assumption).

## Related Issue

Fixes #436 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed