### PR TITLE
fix(validate): fix related observations when empty

### DIFF
--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -251,6 +251,7 @@ func ValidateOnCompDef(compDef *oscalTypes_1_1_2.ComponentDefinition) (map[strin
 				}
 				// Using language from Assessment Results model for Target Objective Status State
 				var state string
+				message.Debugf("Pass: %v / Fail: %v / Existing State: %s", pass, fail, finding.Target.Status.State)
 				if finding.Target.Status.State == "not-satisfied" {
 					state = "not-satisfied"
 				} else if pass > 0 && fail <= 0 {
@@ -270,7 +271,10 @@ func ValidateOnCompDef(compDef *oscalTypes_1_1_2.ComponentDefinition) (map[strin
 					Type:     "objective-id",
 				}
 
-				finding.RelatedObservations = &relatedObservations
+				// Only add related observations if there are any present (preventing an empty array in the field)
+				if len(relatedObservations) > 0 {
+					finding.RelatedObservations = &relatedObservations
+				}
 
 				findings[implementedRequirement.ControlId] = finding
 				observations = append(observations, tempObservations...)


### PR DESCRIPTION
## Description

Validation fails when the assessment results model contains a finding with an empty array for `related-observations`. 

## Related Issue

Fixes #447 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed