### PR TITLE
chore(docs): cleanup unused readme conflicting in docs build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Lula Documentation
-
-### [OPA Provider](opa-provider.md)


### PR DESCRIPTION
## Description

Simple removal of the un-used `README.md` at the root of `/docs` which is breaking link checks on the lula docs site. 

## Related Issue

None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed