### PR TITLE
fix(evaluate): add support for existing control-id becoming satisfied

### DIFF
--- a/src/cmd/evaluate/evaluate.go
+++ b/src/cmd/evaluate/evaluate.go
@@ -98,6 +98,7 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 					message.Infof("%s", finding.Target.TargetId)
 				}
 			}
+			message.Info("Evaluation Passed Successfully")
 
 		} else {
 			message.Warn("Evaluation Failed against the following findings:")

--- a/src/cmd/evaluate/evaluate.go
+++ b/src/cmd/evaluate/evaluate.go
@@ -68,6 +68,8 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 		spinner := message.NewProgressSpinner("Evaluating Assessment Results %s against %s", resultMap["threshold"].UUID, resultMap["latest"].UUID)
 		defer spinner.Stop()
 
+		message.Debugf("threshold UUID: %s / latest UUID: %s", resultMap["threshold"].UUID, resultMap["latest"].UUID)
+
 		status, findings, err := oscal.EvaluateResults(resultMap["threshold"], resultMap["latest"])
 		if err != nil {
 			message.Fatal(err, err.Error())
@@ -84,6 +86,7 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 
 				// Update latest threshold prop
 				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "true", resultMap["latest"].Props)
+				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "false", resultMap["threshold"].Props)
 			} else {
 				// retain result as threshold
 				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "true", resultMap["threshold"].Props)

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -199,6 +199,12 @@ func EvaluateResults(thresholdResult *oscalTypes_1_1_2.Result, newResult *oscalT
 					result = false
 					findings["no-longer-satisfied"] = append(findings["no-longer-satisfied"], finding)
 				}
+			} else {
+				// was previously not-satisfied but now is satisfied
+				if findingMapNew[targetId].Target.Status.State == "satisfied" {
+					// If the new finding is now satisfied - add to new-passing-findings
+					findings["new-passing-findings"] = append(findings["new-passing-findings"], finding)
+				}
 			}
 			delete(findingMapNew, targetId)
 		}

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -67,7 +67,7 @@ func GenerateAssessmentResults(findingMap map[string]oscalTypes_1_1_2.Finding, o
 		{
 			Ns:    "https://docs.lula.dev/ns",
 			Name:  "threshold",
-			Value: "true",
+			Value: "false",
 		},
 	}
 

--- a/src/pkg/common/oscal/assessment-results_test.go
+++ b/src/pkg/common/oscal/assessment-results_test.go
@@ -241,13 +241,17 @@ func TestIdentifyResults(t *testing.T) {
 			t.Fatalf("Expected threshold result to be before latest result")
 		}
 
-		status, _, err := oscal.EvaluateResults(resultMap["threshold"], resultMap["latest"])
+		status, findings, err := oscal.EvaluateResults(resultMap["threshold"], resultMap["latest"])
 		if err != nil {
 			t.Fatalf("Expected error for inability to evaluate multiple results : %v", err)
 		}
 
 		if !status {
 			t.Fatalf("Expected results to be evaluated as failing")
+		}
+
+		if len(findings["new-passing-findings"]) == 0 {
+			t.Fatalf("Expected new passing findings to be found")
 		}
 	})
 


### PR DESCRIPTION
## Description

Edge case for scenarios (albeit a pretty obvious one) where we were not indicating that an existing control-id finding becoming `not-satisfied` to `satisfied` with all other compliance equal should warrant a threshold update.

Leaving debug message for future debug traceability. 

## Related Issue

Fixes #497 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed