### PR TITLE
fix(evaluate): set threshold on single result evaluation

### DIFF
--- a/docs/cli-commands/evaluate.md
+++ b/docs/cli-commands/evaluate.md
@@ -6,19 +6,19 @@ Evaluate serves as a method for verifying the compliance of a component/system a
 
 ### No Existing Data
 
-When no previous assessment exists, the initial assessment is made and stored with `lula validate`. This initial assessment by itself will always pass `lula evaluate` as there is no threshold for evaluation. Lula will automatically apply the `threshold` prop to the assessment result when writing the assessment result to a file that does not contain an existing assessment results artifact.
+When no previous assessment exists, the initial assessment is made and stored with `lula validate`. Lula will automatically apply the `threshold` prop to the assessment result when writing the assessment result to a file that does not contain an existing assessment results artifact. This initial assessment by itself will always pass `lula evaluate` as there is no threshold for evaluation, and the threshold prop with be set to `true`.
 
 steps:
-1. `lula validate`
-2. `lula evaluate` -> Passes with no Threshold
+1. `lula validate -f component.yaml -o assessment-results.yaml`
+2. `lula evaluate -f assessment-results.yaml` -> Passes with no Threshold -> Establishes Threshold
 
 ### Existing Data (Intended Workflow)
 
 In workflows run manually or with automation (such as CI/CD), there is an expectation that the threshold exists, and evaluate will perform an analysis of the compliance of the system/component against the established threshold.
 
 steps:
-1. `lula validate`
-2. `lula evaluate` -> Passes or Fails based on threshold
+1. `lula validate -f component.yaml -o assessment-results.yaml`
+2. `lula evaluate -f assessment-results.yaml` -> Passes or Fails based on threshold
 
 
 ## Scenarios for Consideration

--- a/src/cmd/evaluate/evaluate.go
+++ b/src/cmd/evaluate/evaluate.go
@@ -57,6 +57,10 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 		if err.Error() == "less than 2 results found - no comparison possible" {
 			// Catch and warn of insufficient results
 			message.Warn(err.Error())
+			if len(resultMap) > 0 {
+				// Indicates that there is at least one assessment result
+				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "true", resultMap["latest"].Props)
+			}
 			return
 		} else {
 			message.Fatal(err, err.Error())

--- a/src/cmd/evaluate/evaluate.go
+++ b/src/cmd/evaluate/evaluate.go
@@ -59,9 +59,10 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 			message.Warn(err.Error())
 			if len(resultMap) > 0 {
 				// Indicates that there is at least one assessment result
-				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "true", resultMap["latest"].Props)
+				oscal.UpdateProps("threshold", "https://docs.lula.dev/ns", "true", resultMap["threshold"].Props)
+			} else {
+				return
 			}
-			return
 		} else {
 			message.Fatal(err, err.Error())
 		}
@@ -119,8 +120,6 @@ func EvaluateAssessments(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentRe
 
 	} else if resultMap["threshold"] == nil {
 		message.Fatal(fmt.Errorf("no threshold assessment results could be identified"), "no threshold assessment results could be identified")
-	} else {
-		message.Fatal(fmt.Errorf("no latest assessment results could be identified"), "no latest assessment results could be identified")
 	}
 
 	// Write each file back in the case of modification

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -137,7 +137,7 @@ func IdentifyResults(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentResult
 	// Handle single result found in the assessment-results
 	if len(sortedResults) == 1 {
 		// Only one result found - set latest and return
-		resultMap["latest"] = sortedResults[len(sortedResults)-1]
+		resultMap["threshold"] = sortedResults[len(sortedResults)-1]
 		return resultMap, fmt.Errorf("less than 2 results found - no comparison possible")
 	}
 

--- a/src/pkg/common/oscal/assessment-results.go
+++ b/src/pkg/common/oscal/assessment-results.go
@@ -129,8 +129,16 @@ func IdentifyResults(assessmentMap map[string]*oscalTypes_1_1_2.AssessmentResult
 
 	thresholds, sortedResults := findAndSortResults(assessmentMap)
 
-	if len(sortedResults) <= 1 {
+	// Handle no results found in the assessment-results
+	if len(sortedResults) == 0 {
 		return nil, fmt.Errorf("less than 2 results found - no comparison possible")
+	}
+
+	// Handle single result found in the assessment-results
+	if len(sortedResults) == 1 {
+		// Only one result found - set latest and return
+		resultMap["latest"] = sortedResults[len(sortedResults)-1]
+		return resultMap, fmt.Errorf("less than 2 results found - no comparison possible")
 	}
 
 	if len(thresholds) == 0 {

--- a/src/pkg/common/oscal/assessment-results_test.go
+++ b/src/pkg/common/oscal/assessment-results_test.go
@@ -52,6 +52,27 @@ var observations = []oscalTypes_1_1_2.Observation{
 func TestIdentifyResults(t *testing.T) {
 	t.Parallel()
 
+	// Expecting an error when evaluating assessment without results
+	t.Run("Handle invalid assessment containing no results", func(t *testing.T) {
+
+		var assessment = &oscalTypes_1_1_2.AssessmentResults{
+			UUID: uuid.NewUUID(),
+		}
+		// key name does not matter here
+		var assessmentMap = map[string]*oscalTypes_1_1_2.AssessmentResults{
+			"valid.yaml": assessment,
+		}
+
+		resultMap, err := oscal.IdentifyResults(assessmentMap)
+		if err == nil {
+			t.Fatalf("Expected error for inability to identify multiple results : %v", err)
+		}
+
+		if resultMap != nil {
+			t.Fatalf("Expected resultMap to be nil")
+		}
+	})
+
 	// Expecting an error when evaluating a single result
 	t.Run("Handle valid assessment containing a single result", func(t *testing.T) {
 
@@ -65,9 +86,17 @@ func TestIdentifyResults(t *testing.T) {
 			"valid.yaml": assessment,
 		}
 
-		_, err = oscal.IdentifyResults(assessmentMap)
+		resultMap, err := oscal.IdentifyResults(assessmentMap)
 		if err == nil {
 			t.Fatalf("Expected error for inability to identify multiple results : %v", err)
+		}
+
+		if resultMap == nil {
+			t.Fatalf("Expected resultMap to be non-nil")
+		}
+
+		if len(resultMap) == 0 {
+			t.Fatalf("Expected resultMap to contain the single result")
 		}
 	})
 


### PR DESCRIPTION
## Description

Enables `evaluate` to set the `threshold` property to `true` when executed against an assessment-results artifact with a single result. This aligns to intended workflows for producing the initial threshold (whether manually or within CI/CD). 

## Related Issue

Fixes #513 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed