### PR TITLE
chore(docs): correcting cli command in simple demo

### DIFF
--- a/docs/getting-started/simple-demo.md
+++ b/docs/getting-started/simple-demo.md
@@ -177,7 +177,7 @@ The following simple demo will step through a process to validate and evaluate K
 
 7. Now that two assessment-results are established, the `threshold` can be evaluated. Perform an `evaluate` to compare the old and new state of the cluster:
     ```shell
-    lula evaluate -f oscal-component-opa.yaml
+    lula evaluate -f assessment-results.yaml
     ```
 
     The output will show that now the new threshold for the system assessment is the more _compliant_ evaluation of the control - i.e., the `satisfied` value of the Control ID-1 is the threshold.


### PR DESCRIPTION
## Description

Currently the CLI code snippet in step 7 of the Simple Demo refers to the `oscal-component-opa.yaml` file. The `lula evaluate` command should provide an assessment results file (or two). The change is to replace `oscal-compmonent-opa.yaml` with `assessment-results.yaml` in that code snippet.
## Related Issue

Due to simplicity of fix (only a typo in the docs), an issue wasn't needed (per contribution standards, trivial fixes don't require issues).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ N/A ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed