### PR TITLE
fix(release): configuration to bump minor version when including features

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
     "packages": {
         ".": {
             "bump-minor-pre-major": true,
-            "bump-patch-for-minor-pre-major": true,
             "release-type": "go",
             "draft": true,
             "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Description

Given the semantic versioning guidance for features (linked in the issue) - modification of the release please configuration to allow features to bump minor version instead of patch. 

[Release Please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)

## Related Issue

Fixes #569 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed