### PR TITLE
fix(gen-cli-docs): fix path for gen-cli-docs

### DIFF
--- a/docs/cli-commands/lula.md
+++ b/docs/cli-commands/lula.md
@@ -20,12 +20,12 @@ Real Time Risk Transparency through automated validation
 
 ### SEE ALSO
 
-* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
-* [lula console](/cli-commands/lula_console/)	 - Console terminal user interface for OSCAL models
-* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
-* [lula evaluate](/cli-commands/lula_evaluate/)	 - evaluate two results of a Security Assessment Results
-* [lula generate](/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
-* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
-* [lula validate](/cli-commands/lula_validate/)	 - validate an OSCAL component definition
-* [lula version](/cli-commands/lula_version/)	 - Shows the current version of the Lula binary
+* [lula completion](./lula_completion.md)	 - Generate the autocompletion script for the specified shell
+* [lula console](./lula_console.md)	 - Console terminal user interface for OSCAL models
+* [lula dev](./lula_dev.md)	 - Collection of dev commands to make dev life easier
+* [lula evaluate](./lula_evaluate.md)	 - evaluate two results of a Security Assessment Results
+* [lula generate](./lula_generate.md)	 - Generate a specified compliance artifact template
+* [lula tools](./lula_tools.md)	 - Collection of additional commands to make OSCAL easier
+* [lula validate](./lula_validate.md)	 - validate an OSCAL component definition
+* [lula version](./lula_version.md)	 - Shows the current version of the Lula binary
 

--- a/docs/cli-commands/lula.md
+++ b/docs/cli-commands/lula.md
@@ -20,12 +20,12 @@ Real Time Risk Transparency through automated validation
 
 ### SEE ALSO
 
-* [lula completion](/cli/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
-* [lula console](/cli/cli-commands/lula_console/)	 - Console terminal user interface for OSCAL models
-* [lula dev](/cli/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
-* [lula evaluate](/cli/cli-commands/lula_evaluate/)	 - evaluate two results of a Security Assessment Results
-* [lula generate](/cli/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
-* [lula tools](/cli/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
-* [lula validate](/cli/cli-commands/lula_validate/)	 - validate an OSCAL component definition
-* [lula version](/cli/cli-commands/lula_version/)	 - Shows the current version of the Lula binary
+* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula console](/cli-commands/lula_console/)	 - Console terminal user interface for OSCAL models
+* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula evaluate](/cli-commands/lula_evaluate/)	 - evaluate two results of a Security Assessment Results
+* [lula generate](/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
+* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula validate](/cli-commands/lula_validate/)	 - validate an OSCAL component definition
+* [lula version](/cli-commands/lula_version/)	 - Shows the current version of the Lula binary
 

--- a/docs/cli-commands/lula_completion.md
+++ b/docs/cli-commands/lula_completion.md
@@ -27,9 +27,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
-* [lula completion bash](/cli/cli-commands/lula_completion_bash/)	 - Generate the autocompletion script for bash
-* [lula completion fish](/cli/cli-commands/lula_completion_fish/)	 - Generate the autocompletion script for fish
-* [lula completion powershell](/cli/cli-commands/lula_completion_powershell/)	 - Generate the autocompletion script for powershell
-* [lula completion zsh](/cli/cli-commands/lula_completion_zsh/)	 - Generate the autocompletion script for zsh
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula completion bash](/cli-commands/lula_completion_bash/)	 - Generate the autocompletion script for bash
+* [lula completion fish](/cli-commands/lula_completion_fish/)	 - Generate the autocompletion script for fish
+* [lula completion powershell](/cli-commands/lula_completion_powershell/)	 - Generate the autocompletion script for powershell
+* [lula completion zsh](/cli-commands/lula_completion_zsh/)	 - Generate the autocompletion script for zsh
 

--- a/docs/cli-commands/lula_completion.md
+++ b/docs/cli-commands/lula_completion.md
@@ -27,9 +27,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
-* [lula completion bash](/cli-commands/lula_completion_bash/)	 - Generate the autocompletion script for bash
-* [lula completion fish](/cli-commands/lula_completion_fish/)	 - Generate the autocompletion script for fish
-* [lula completion powershell](/cli-commands/lula_completion_powershell/)	 - Generate the autocompletion script for powershell
-* [lula completion zsh](/cli-commands/lula_completion_zsh/)	 - Generate the autocompletion script for zsh
+* [lula](./lula.md)	 - Risk Management as Code
+* [lula completion bash](./lula_completion_bash.md)	 - Generate the autocompletion script for bash
+* [lula completion fish](./lula_completion_fish.md)	 - Generate the autocompletion script for fish
+* [lula completion powershell](./lula_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [lula completion zsh](./lula_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/docs/cli-commands/lula_completion_bash.md
+++ b/docs/cli-commands/lula_completion_bash.md
@@ -50,5 +50,5 @@ lula completion bash
 
 ### SEE ALSO
 
-* [lula completion](/cli/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_bash.md
+++ b/docs/cli-commands/lula_completion_bash.md
@@ -50,5 +50,5 @@ lula completion bash
 
 ### SEE ALSO
 
-* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](./lula_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_fish.md
+++ b/docs/cli-commands/lula_completion_fish.md
@@ -41,5 +41,5 @@ lula completion fish [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_fish.md
+++ b/docs/cli-commands/lula_completion_fish.md
@@ -41,5 +41,5 @@ lula completion fish [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](./lula_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_powershell.md
+++ b/docs/cli-commands/lula_completion_powershell.md
@@ -38,5 +38,5 @@ lula completion powershell [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_powershell.md
+++ b/docs/cli-commands/lula_completion_powershell.md
@@ -38,5 +38,5 @@ lula completion powershell [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](./lula_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_zsh.md
+++ b/docs/cli-commands/lula_completion_zsh.md
@@ -52,5 +52,5 @@ lula completion zsh [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_completion_zsh.md
+++ b/docs/cli-commands/lula_completion_zsh.md
@@ -52,5 +52,5 @@ lula completion zsh [flags]
 
 ### SEE ALSO
 
-* [lula completion](/cli-commands/lula_completion/)	 - Generate the autocompletion script for the specified shell
+* [lula completion](./lula_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/docs/cli-commands/lula_console.md
+++ b/docs/cli-commands/lula_console.md
@@ -42,5 +42,5 @@ To view an OSCAL model in the Console:
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula](./lula.md)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_console.md
+++ b/docs/cli-commands/lula_console.md
@@ -42,5 +42,5 @@ To view an OSCAL model in the Console:
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_dev.md
+++ b/docs/cli-commands/lula_dev.md
@@ -21,8 +21,8 @@ Collection of dev commands to make dev life easier
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
-* [lula dev get-resources](/cli/cli-commands/lula_dev_get-resources/)	 - Get Resources from a Lula Validation Manifest
-* [lula dev lint](/cli/cli-commands/lula_dev_lint/)	 - Lint validation files against schema
-* [lula dev validate](/cli/cli-commands/lula_dev_validate/)	 - Run an individual Lula validation.
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula dev get-resources](/cli-commands/lula_dev_get-resources/)	 - Get Resources from a Lula Validation Manifest
+* [lula dev lint](/cli-commands/lula_dev_lint/)	 - Lint validation files against schema
+* [lula dev validate](/cli-commands/lula_dev_validate/)	 - Run an individual Lula validation.
 

--- a/docs/cli-commands/lula_dev.md
+++ b/docs/cli-commands/lula_dev.md
@@ -21,8 +21,8 @@ Collection of dev commands to make dev life easier
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
-* [lula dev get-resources](/cli-commands/lula_dev_get-resources/)	 - Get Resources from a Lula Validation Manifest
-* [lula dev lint](/cli-commands/lula_dev_lint/)	 - Lint validation files against schema
-* [lula dev validate](/cli-commands/lula_dev_validate/)	 - Run an individual Lula validation.
+* [lula](./lula.md)	 - Risk Management as Code
+* [lula dev get-resources](./lula_dev_get-resources.md)	 - Get Resources from a Lula Validation Manifest
+* [lula dev lint](./lula_dev_lint.md)	 - Lint validation files against schema
+* [lula dev validate](./lula_dev_validate.md)	 - Run an individual Lula validation.
 

--- a/docs/cli-commands/lula_dev_get-resources.md
+++ b/docs/cli-commands/lula_dev_get-resources.md
@@ -52,5 +52,5 @@ To hang for timeout of 5 seconds:
 
 ### SEE ALSO
 
-* [lula dev](/cli/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_dev_get-resources.md
+++ b/docs/cli-commands/lula_dev_get-resources.md
@@ -52,5 +52,5 @@ To hang for timeout of 5 seconds:
 
 ### SEE ALSO
 
-* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](./lula_dev.md)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_dev_lint.md
+++ b/docs/cli-commands/lula_dev_lint.md
@@ -40,5 +40,5 @@ To lint existing validation files:
 
 ### SEE ALSO
 
-* [lula dev](/cli/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_dev_lint.md
+++ b/docs/cli-commands/lula_dev_lint.md
@@ -40,5 +40,5 @@ To lint existing validation files:
 
 ### SEE ALSO
 
-* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](./lula_dev.md)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_dev_validate.md
+++ b/docs/cli-commands/lula_dev_validate.md
@@ -54,5 +54,5 @@ To hang for timeout of 5 seconds:
 
 ### SEE ALSO
 
-* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](./lula_dev.md)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_dev_validate.md
+++ b/docs/cli-commands/lula_dev_validate.md
@@ -54,5 +54,5 @@ To hang for timeout of 5 seconds:
 
 ### SEE ALSO
 
-* [lula dev](/cli/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
+* [lula dev](/cli-commands/lula_dev/)	 - Collection of dev commands to make dev life easier
 

--- a/docs/cli-commands/lula_evaluate.md
+++ b/docs/cli-commands/lula_evaluate.md
@@ -48,5 +48,5 @@ To target a specific framework for validation:
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula](./lula.md)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_evaluate.md
+++ b/docs/cli-commands/lula_evaluate.md
@@ -48,5 +48,5 @@ To target a specific framework for validation:
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_generate.md
+++ b/docs/cli-commands/lula_generate.md
@@ -23,6 +23,6 @@ Generate a specified compliance artifact template
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
-* [lula generate component](/cli-commands/lula_generate_component/)	 - Generate a component definition OSCAL template
+* [lula](./lula.md)	 - Risk Management as Code
+* [lula generate component](./lula_generate_component.md)	 - Generate a component definition OSCAL template
 

--- a/docs/cli-commands/lula_generate.md
+++ b/docs/cli-commands/lula_generate.md
@@ -23,6 +23,6 @@ Generate a specified compliance artifact template
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
-* [lula generate component](/cli/cli-commands/lula_generate_component/)	 - Generate a component definition OSCAL template
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula generate component](/cli-commands/lula_generate_component/)	 - Generate a component definition OSCAL template
 

--- a/docs/cli-commands/lula_generate_component.md
+++ b/docs/cli-commands/lula_generate_component.md
@@ -52,5 +52,5 @@ lula generate component -c <catalog source url> -r control-a --remarks guidance,
 
 ### SEE ALSO
 
-* [lula generate](/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
+* [lula generate](./lula_generate.md)	 - Generate a specified compliance artifact template
 

--- a/docs/cli-commands/lula_generate_component.md
+++ b/docs/cli-commands/lula_generate_component.md
@@ -52,5 +52,5 @@ lula generate component -c <catalog source url> -r control-a --remarks guidance,
 
 ### SEE ALSO
 
-* [lula generate](/cli/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
+* [lula generate](/cli-commands/lula_generate/)	 - Generate a specified compliance artifact template
 

--- a/docs/cli-commands/lula_tools.md
+++ b/docs/cli-commands/lula_tools.md
@@ -21,9 +21,9 @@ Collection of additional commands to make OSCAL easier
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
-* [lula tools compose](/cli/cli-commands/lula_tools_compose/)	 - compose an OSCAL component definition
-* [lula tools lint](/cli/cli-commands/lula_tools_lint/)	 - Validate OSCAL against schema
-* [lula tools upgrade](/cli/cli-commands/lula_tools_upgrade/)	 - Upgrade OSCAL document to a new version if possible.
-* [lula tools uuidgen](/cli/cli-commands/lula_tools_uuidgen/)	 - Generate a UUID
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula tools compose](/cli-commands/lula_tools_compose/)	 - compose an OSCAL component definition
+* [lula tools lint](/cli-commands/lula_tools_lint/)	 - Validate OSCAL against schema
+* [lula tools upgrade](/cli-commands/lula_tools_upgrade/)	 - Upgrade OSCAL document to a new version if possible.
+* [lula tools uuidgen](/cli-commands/lula_tools_uuidgen/)	 - Generate a UUID
 

--- a/docs/cli-commands/lula_tools.md
+++ b/docs/cli-commands/lula_tools.md
@@ -21,9 +21,9 @@ Collection of additional commands to make OSCAL easier
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
-* [lula tools compose](/cli-commands/lula_tools_compose/)	 - compose an OSCAL component definition
-* [lula tools lint](/cli-commands/lula_tools_lint/)	 - Validate OSCAL against schema
-* [lula tools upgrade](/cli-commands/lula_tools_upgrade/)	 - Upgrade OSCAL document to a new version if possible.
-* [lula tools uuidgen](/cli-commands/lula_tools_uuidgen/)	 - Generate a UUID
+* [lula](./lula.md)	 - Risk Management as Code
+* [lula tools compose](./lula_tools_compose.md)	 - compose an OSCAL component definition
+* [lula tools lint](./lula_tools_lint.md)	 - Validate OSCAL against schema
+* [lula tools upgrade](./lula_tools_upgrade.md)	 - Upgrade OSCAL document to a new version if possible.
+* [lula tools uuidgen](./lula_tools_uuidgen.md)	 - Generate a UUID
 

--- a/docs/cli-commands/lula_tools_compose.md
+++ b/docs/cli-commands/lula_tools_compose.md
@@ -43,5 +43,5 @@ To indicate a specific output file:
 
 ### SEE ALSO
 
-* [lula tools](/cli/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_compose.md
+++ b/docs/cli-commands/lula_tools_compose.md
@@ -43,5 +43,5 @@ To indicate a specific output file:
 
 ### SEE ALSO
 
-* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](./lula_tools.md)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_lint.md
+++ b/docs/cli-commands/lula_tools_lint.md
@@ -41,5 +41,5 @@ To lint existing OSCAL files:
 
 ### SEE ALSO
 
-* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](./lula_tools.md)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_lint.md
+++ b/docs/cli-commands/lula_tools_lint.md
@@ -41,5 +41,5 @@ To lint existing OSCAL files:
 
 ### SEE ALSO
 
-* [lula tools](/cli/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_upgrade.md
+++ b/docs/cli-commands/lula_tools_upgrade.md
@@ -42,5 +42,5 @@ To Upgrade an existing OSCAL file:
 
 ### SEE ALSO
 
-* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](./lula_tools.md)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_upgrade.md
+++ b/docs/cli-commands/lula_tools_upgrade.md
@@ -42,5 +42,5 @@ To Upgrade an existing OSCAL file:
 
 ### SEE ALSO
 
-* [lula tools](/cli/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_uuidgen.md
+++ b/docs/cli-commands/lula_tools_uuidgen.md
@@ -41,5 +41,5 @@ To create a deterministic UUID given some source:
 
 ### SEE ALSO
 
-* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](./lula_tools.md)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_tools_uuidgen.md
+++ b/docs/cli-commands/lula_tools_uuidgen.md
@@ -41,5 +41,5 @@ To create a deterministic UUID given some source:
 
 ### SEE ALSO
 
-* [lula tools](/cli/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
+* [lula tools](/cli-commands/lula_tools/)	 - Collection of additional commands to make OSCAL easier
 

--- a/docs/cli-commands/lula_validate.md
+++ b/docs/cli-commands/lula_validate.md
@@ -51,5 +51,5 @@ To run validations non-interactively (no execution)
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_validate.md
+++ b/docs/cli-commands/lula_validate.md
@@ -51,5 +51,5 @@ To run validations non-interactively (no execution)
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula](./lula.md)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_version.md
+++ b/docs/cli-commands/lula_version.md
@@ -38,5 +38,5 @@ Get the current Lula version:
 
 ### SEE ALSO
 
-* [lula](/cli/cli-commands/lula/)	 - Risk Management as Code
+* [lula](/cli-commands/lula/)	 - Risk Management as Code
 

--- a/docs/cli-commands/lula_version.md
+++ b/docs/cli-commands/lula_version.md
@@ -38,5 +38,5 @@ Get the current Lula version:
 
 ### SEE ALSO
 
-* [lula](/cli-commands/lula/)	 - Risk Management as Code
+* [lula](./lula.md)	 - Risk Management as Code
 

--- a/docs/getting-started/simple-demo.md
+++ b/docs/getting-started/simple-demo.md
@@ -1,6 +1,6 @@
 # Simple Demo
 
-The following simple demo will step through a process to validate and evaluate Kubernets cluster resources for a simple `component-definition`. The following pre-requisites are required to successfully run this demo:
+The following simple demo will step through a process to validate and evaluate Kubernetes cluster resources for a simple `component-definition`. The following pre-requisites are required to successfully run this demo:
 
 ### Pre-Requisites
 

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -58,7 +58,7 @@ type: docs
 		}
 
 		var linkHandler = func(link string) string {
-			return "/cli/cli-commands/" + link[:len(link)-3] + "/"
+			return "/cli-commands/" + link[:len(link)-3] + "/"
 		}
 
 		err = doc.GenMarkdownTreeCustom(rootCmd, "./docs/cli-commands", prependTitle, linkHandler)

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -58,7 +58,7 @@ type: docs
 		}
 
 		var linkHandler = func(link string) string {
-			return "/cli-commands/" + link[:len(link)-3] + "/"
+			return "./" + link
 		}
 
 		err = doc.GenMarkdownTreeCustom(rootCmd, "./docs/cli-commands", prependTitle, linkHandler)


### PR DESCRIPTION
## Description

Update the `gen-cli-docs` command to generate links that the docs website will resolve. The reference needs to originate from root ie `/cli-commands/<command>`

## Related Issue

Fixes #645 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed