### PR TITLE
fix: cleaned whitespace+newline in rego

### DIFF
--- a/src/pkg/common/common_test.go
+++ b/src/pkg/common/common_test.go
@@ -18,6 +18,7 @@ import (
 
 const multiValidationPath = "../../test/e2e/scenarios/remote-validations/multi-validations.yaml"
 const singleValidationPath = "../../test/e2e/scenarios/remote-validations/validation.opa.yaml"
+const whitespaceValidationPath = "../../test/e2e/scenarios/remote-validations/validation.whitespace.yaml"
 
 // Helper function to load test data
 func loadTestData(t *testing.T, path string) []byte {
@@ -390,6 +391,29 @@ func TestValidationToResource(t *testing.T) {
 
 		if resource.UUID == validation.Metadata.UUID {
 			t.Errorf("ToResource() description = \"\", want a valid UUID")
+		}
+	})
+
+	t.Run("It trims whitespace from the validation", func(t *testing.T) {
+		t.Parallel()
+		validationBytes := loadTestData(t, whitespaceValidationPath)
+
+		validation, err := common.ReadValidationsFromYaml(validationBytes)
+		if err != nil {
+			t.Fatalf("yaml.Unmarshal failed: %v", err)
+		}
+
+		if len(validation) > 1 {
+			t.Errorf("Expected 1 validation, got %d", len(validation))
+		}
+
+		resource, err := validation[0].ToResource()
+		if err != nil {
+			t.Errorf("ToResource() error = %v", err)
+		}
+		strings.Contains(resource.Description, " \n")
+		if strings.Contains(resource.Description, " \n") {
+			t.Errorf("ToResource() description = should not contain whitespace followed by newline")
 		}
 	})
 }

--- a/src/pkg/common/types.go
+++ b/src/pkg/common/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
@@ -55,6 +56,12 @@ func (v *Validation) ToResource() (resource *oscalTypes_1_1_2.Resource, err erro
 	} else {
 		resource.UUID = uuid.NewUUID()
 	}
+	// If the provider is opa, trim whitespace from the rego
+	if v.Provider != nil && v.Provider.OpaSpec != nil {
+		re := regexp.MustCompile(`[ \t]+\r?\n`)
+		v.Provider.OpaSpec.Rego = re.ReplaceAllString(v.Provider.OpaSpec.Rego, "\n")
+	}
+
 	validationBytes, err := v.MarshalYaml()
 	if err != nil {
 		return nil, err

--- a/src/test/e2e/scenarios/remote-validations/validation.whitespace.yaml
+++ b/src/test/e2e/scenarios/remote-validations/validation.whitespace.yaml
@@ -1,0 +1,27 @@
+lula-version: ">=v0.2.0"
+metadata:
+  name: Validate pods with label foo=bar
+  uuid: 7f4c3b2a-1c3d-4a2b-8b64-3b1f76a8e36f
+domain:
+  type: kubernetes
+  kubernetes-spec:
+    resources:
+      - name: podsvt
+        resource-rule:
+          version: v1
+          resource: pods
+          namespaces: [validation-test]
+provider:
+  type: opa
+  opa-spec:
+    rego: |
+      package validate
+
+      import future.keywords.every 
+
+      validate {
+        every pod in input.podsvt {
+          podLabel := pod.metadata.labels.foo
+          podLabel == "bar"
+        }
+      }


### PR DESCRIPTION
## Description

Fixes the rego-becomes-a-single-string problem when any of the rego has whitespace followed by a newline character. Only impacts the "compose" functionality

## Related Issue

Fixes #483 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed