### PR TITLE
fix: trim whitespace bug

### DIFF
--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -661,10 +661,12 @@ func addPart(part *[]oscalTypes_1_1_2.Part, paramMap map[string]parameter, level
 			}
 
 			var tabs string
-			for range level {
+			// Indents based on labels
+			for i := 0; i < level; i++ {
 				tabs += "\t"
 			}
-			prose := part.Prose
+			// Trims the whitespace
+			prose := strings.TrimSpace(part.Prose)
 			if prose == "" {
 				result += fmt.Sprintf("%s%s\n", tabs, label)
 			} else if strings.Contains(prose, "{{ insert: param,") {


### PR DESCRIPTION
## Description

Trimming the whitespace in the addPart function fixes the format issues in the bug below.

It did create a new issue with indenting nested assessment objectives so added the quick fix for that.

## Related Issue

Fixes # https://github.com/defenseunicorns/lula/issues/676

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed