### PR TITLE
feat(file domain): add support for reading arbitrary files as strings

### DIFF
--- a/docs/reference/domains/file-domain.md
+++ b/docs/reference/domains/file-domain.md
@@ -11,33 +11,41 @@ domain:
     filepaths:
     - name: config
       path: grafana.ini
+      parser: ini         # optionally specify which parser to use for the file type
 ```
 
 ## Supported File Types
-The file domain uses OPA's [conftest](https://conftest.dev) to parse files into a json-compatible format for validations. ∑Both OPA and Kyverno (using [kyverno-json](https://kyverno.github.io/kyverno-json/latest/)) can validate files parsed by the file domain.
+The file domain uses OPA's [conftest](https://conftest.dev) to parse files into a json-compatible format for validations. Both OPA and Kyverno (using [kyverno-json](https://kyverno.github.io/kyverno-json/latest/)) can validate files parsed by the file domain.
 
-The file domain supports the following file formats for validation:
-* CUE
-* CycloneDX
-* Dockerfile
-* EDN
-* Environment files (.env)
-* HCL and HCL2
-* HOCON
-* Ignore files (.gitignore, .dockerignore)
-* INI
-* JSON
-* Jsonnet
-* Property files (.properties)
-* SPDX
-* TextProto (Protocol Buffers)
-* TOML
-* VCL
-* XML
-* YAML
+The file domain includes the following file parsers:
+* cue
+* cyclonedx
+* dockerfile
+* edn
+* hcl1
+* hcl2
+* hocon
+* ignore
+* ini
+* json
+* jsonc
+* jsonnet
+* properties
+* spdx
+* textproto
+* toml
+* vcl
+* xml
+* yaml
+* dotenv
+* string
+
+The file domain can also parse arbitrary file types as strings. The entire file contents will be represented as a single string.
+
+The file parser can usually be inferred from the file extension. However, if the file extension does not match the filetype you are parsing (for example, if you have a json file that does not have a `.json` extension), or if you wish to parse an arbitrary file type as a string, use the `parser` field in the FileSpec to specify which parser to use.
 
 ## Validations
-When writing validations against files, the filepath `Name` must be included as
+When writing validations against files, the filepath `name` must be included as
 the top-level key in the validation. The placement varies between providers.
 
 Given the following ini file:

--- a/docs/reference/domains/file-domain.md
+++ b/docs/reference/domains/file-domain.md
@@ -21,6 +21,7 @@ The file domain includes the following file parsers:
 * cue
 * cyclonedx
 * dockerfile
+* dotenv
 * edn
 * hcl1
 * hcl2
@@ -32,17 +33,16 @@ The file domain includes the following file parsers:
 * jsonnet
 * properties
 * spdx
+* string
 * textproto
 * toml
 * vcl
 * xml
 * yaml
-* dotenv
-* string
 
 The file domain can also parse arbitrary file types as strings. The entire file contents will be represented as a single string.
 
-The file parser can usually be inferred from the file extension. However, if the file extension does not match the filetype you are parsing (for example, if you have a json file that does not have a `.json` extension), or if you wish to parse an arbitrary file type as a string, use the `parser` field in the FileSpec to specify which parser to use.
+The file parser can usually be inferred from the file extension. However, if the file extension does not match the filetype you are parsing (for example, if you have a json file that does not have a `.json` extension), or if you wish to parse an arbitrary file type as a string, use the `parser` field in the FileSpec to specify which parser to use. The list above contains all the available parses. 
 
 ## Validations
 When writing validations against files, the filepath `name` must be included as
@@ -130,6 +130,70 @@ provider:
       validation: validate.validate
       observations:
         - validate.msg
+```
+
+### Parsing files as arbitrary strings
+Files that are parsed as strings are represented as a key-value pair where the key is the user-supplied file `name` and the value is a string representation of the file contexts, including special characters, for e.g. newlines (`\n`). 
+
+As an example, let's parse a similar file as before as an arbitrary string. 
+
+When reading the following multiline file contents as a string:
+```server.txt
+server = https
+port = 3000
+```
+
+The resources for validation will be formatted as a single string with newline characters:
+
+```
+{"config": "server = https\nport = 3000"}
+```
+
+And the following validation will confirm if the server is configured for https:
+```validation.yaml
+  domain:
+    type: file
+    file-spec:
+      filepaths:
+      - name: 'config'
+        path: 'server.txt'
+        parser: string
+  provider:
+    type: opa
+    opa-spec:
+      rego: |
+        package validate
+        import rego.v1
+
+        # Default values
+        default validate := false
+        default msg := "Not evaluated"
+        
+        validate if {
+          check_server_protocol.result
+        }
+        msg = check_server_protocol.msg
+        
+        config := input["config"]
+        
+        check_server_protocol = {"result": true, "msg": msg} if {
+          regex.match(
+            `server = https\n`,
+            config
+          )
+          msg := "Server protocol is set to https"
+        } else = {"result": false, "msg": msg} if {
+          regex.match(
+            `server = http\n`,
+            config
+          )
+          msg := "Server Protocol must be https - http is disallowed"
+        }
+
+      output:
+        validation: validate.validate
+        observations:
+          - validate.msg
 ```
 
 ## Note on Compose

--- a/src/pkg/common/schemas/validation.json
+++ b/src/pkg/common/schemas/validation.json
@@ -381,6 +381,32 @@
                             },
                             "path": {
                                 "type": "string"
+                            },
+                            "parser": {
+                                "type": "string",
+                                "enum": [
+                                    "cue",
+                                    "cyclonedx",
+                                    "dockerfile",
+                                    "edn",
+                                    "hcl1",
+                                    "hcl2",
+                                    "hocon",
+                                    "ignore",
+                                    "ini",
+                                    "json",
+                                    "jsonc",
+                                    "jsonnet",
+                                    "properties",
+                                    "spdx",
+                                    "textproto",
+                                    "toml",
+                                    "vcl",
+                                    "xml",
+                                    "yaml",
+                                    "dotenv",
+                                    "string"
+                                ]
                             }
                         }
                     }

--- a/src/pkg/domains/files/files_test.go
+++ b/src/pkg/domains/files/files_test.go
@@ -16,6 +16,7 @@ func TestGetResource(t *testing.T) {
 		d := Domain{Spec: &Spec{Filepaths: []FileInfo{
 			{Name: "foo.yaml", Path: "foo.yaml"},
 			{Name: "bar.json", Path: "bar.json"},
+			{Name: "baz", Path: "baz", Parser: "json"},
 			{Name: "arbitraryname", Path: "nested-directory/baz.hcl2"},
 			{Name: "stringtheory", Path: "arbitrary.file", Parser: "string"},
 		}}}
@@ -25,6 +26,7 @@ func TestGetResource(t *testing.T) {
 		if diff := cmp.Diff(resources, types.DomainResources{
 			"bar.json": map[string]interface{}{"cat": "Cheetarah"},
 			"foo.yaml": "cat = Li Shou",
+			"baz":      map[string]interface{}{"lizard": "Snakob"},
 			"arbitraryname": map[string]any{
 				"resource": map[string]any{"catname": map[string]any{"blackcat": map[string]any{"name": "robin"}}},
 			},

--- a/src/pkg/domains/files/files_test.go
+++ b/src/pkg/domains/files/files_test.go
@@ -17,6 +17,7 @@ func TestGetResource(t *testing.T) {
 			{Name: "foo.yaml", Path: "foo.yaml"},
 			{Name: "bar.json", Path: "bar.json"},
 			{Name: "arbitraryname", Path: "nested-directory/baz.hcl2"},
+			{Name: "stringtheory", Path: "arbitrary.file", Parser: "string"},
 		}}}
 
 		resources, err := d.GetResources(context.WithValue(context.Background(), types.LulaValidationWorkDir, "testdata"))
@@ -27,6 +28,7 @@ func TestGetResource(t *testing.T) {
 			"arbitraryname": map[string]any{
 				"resource": map[string]any{"catname": map[string]any{"blackcat": map[string]any{"name": "robin"}}},
 			},
+			"stringtheory": "hello there!",
 		}); diff != "" {
 			t.Fatalf("wrong result:\n%s\n", diff)
 		}

--- a/src/pkg/domains/files/spec.go
+++ b/src/pkg/domains/files/spec.go
@@ -5,6 +5,7 @@ type Spec struct {
 }
 
 type FileInfo struct {
-	Name string `json:"name" yaml:"name"`
-	Path string `json:"path" yaml:"path"`
+	Name   string `json:"name" yaml:"name"`
+	Path   string `json:"path" yaml:"path"`
+	Parser string `json:"parser,omitempty" yaml:"parser,omitempty"`
 }

--- a/src/pkg/domains/files/testdata/arbitrary.file
+++ b/src/pkg/domains/files/testdata/arbitrary.file
@@ -1,0 +1,1 @@
+hello there!

--- a/src/pkg/domains/files/testdata/baz
+++ b/src/pkg/domains/files/testdata/baz
@@ -1,0 +1,1 @@
+{ "lizard": "Snakob"}

--- a/src/test/e2e/scenarios/file-validations/pass/component-definition-string-file.yaml
+++ b/src/test/e2e/scenarios/file-validations/pass/component-definition-string-file.yaml
@@ -1,0 +1,89 @@
+component-definition:
+  uuid: E6A291A4-2BC8-43A0-B4B2-FD67CAAE1F8F
+  metadata:
+    title: OSCAL Demo Tool
+    last-modified: "2022-09-13T12:00:00Z"
+    version: "20220913"
+    oscal-version: 1.1.1
+    parties:
+      # Should be consistent across all of the packages, but where is ground truth?
+      - uuid: C18F4A9F-A402-415B-8D13-B51739D689FF
+        type: organization
+        name: Defense Unicorns
+        links:
+          - href: https://github.com/defenseunicorns/lula
+            rel: website
+  components:
+    - uuid: A9D5204C-7E5B-4C43-BD49-34DF759B9F04
+      type: software
+      title: lula
+      description: |
+        Defense Unicorns lula
+      purpose: Validate compliance controls
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - C18F4A9F-A402-415B-8D13-B51739D689FF # matches parties entry for Defense Unicorns
+      control-implementations:
+        - uuid: A584FEDC-8CEA-4B0C-9F07-85C2C4AE751A
+          source: https://github.com/defenseunicorns/lula
+          description: Validate generic security requirements
+          implemented-requirements:
+            - uuid: 42C2FFDC-5F05-44DF-A67F-EEC8660AEFFD
+              control-id: ID-1
+              description: >-
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, 
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum 
+                dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              links:
+                - href: "#88AB3470-B96B-4D7C-BC36-02BF9563C46C"
+                  rel: lula
+  back-matter: 
+      resources:
+      - uuid: 88AB3470-B96B-4D7C-BC36-02BF9563C46C
+        rlinks:
+          - href: lula
+        description: |
+          domain:
+            type: file
+            file-spec:
+              filepaths:
+              - Name: config
+                path: config.string
+                parser: string
+          provider:
+            type: opa
+            opa-spec:
+              rego: |
+                package validate
+                import rego.v1
+
+                # Default values
+                default validate := false
+                default msg := "Not evaluated"
+                
+                validate if {
+                  check_server_protocol.result
+                }
+                msg = check_server_protocol.msg
+                
+                config := input["config"]
+                
+                check_server_protocol = {"result": true, "msg": msg} if {
+                  regex.match(
+                    `server = https\n`,
+                    config
+                  )
+                  msg := "Server protocol is set to https"
+                } else = {"result": false, "msg": msg} if {
+                  regex.match(
+                    `server = http\n`,
+                    config
+                  )
+                  msg := "Server Protocol must be https - http is disallowed"
+                }
+
+              output:
+                validation: validate.validate
+                observations:
+                  - validate.msg

--- a/src/test/e2e/scenarios/file-validations/pass/config.string
+++ b/src/test/e2e/scenarios/file-validations/pass/config.string
@@ -1,0 +1,2 @@
+server = https
+something = else


### PR DESCRIPTION
## Description
This PR adds support for arbitrary file contents read in as strings. Line endings are relevant when writing regexes, so I did absolutely nothing fancy when reading the file: go will preserver tabs and newlines, and users will need to be aware of that when writing validations. 

I will add more to the documentation about how to write a validation for a string-blob, but I wanted to see if the team had objections to the format before I do so. It's valid to say we're going to read it as a giant single string with no extra lines, tabs, or spaces, but that seemed unhelpful when trying to write a validation.

This also supports passing the name of the parser for any given file, not just the string file. The initial list is all of the conftest parsers supported as of the time of writing, plus our custom string parser. If the user specifies a `parser` in the file spec, that file will get special handling. Everything except the "string" parser gets passed into conftest's `ParseConfigurationAs` method with the parser name (I added it as an enum in the schema, so I'm not doing any other validation, but if I should add that for other callers I shall!), while strings get slurped into memory then added to the parsed configs map.  

I've added some tests (e2e and unit) for: 
- string files
- a json file without a file extension, using the json parser

I'm always willing to add tests, let me know what you'd like to see! I'll add some more words to the documentation once folks get a chance to comment on the string file format.  

## Related Issue

Closes #709 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [ x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed