### PR TITLE
chore: address linter report - swallowed errors and minor test cleanup

### DIFF
--- a/src/cmd/common/setup.go
+++ b/src/cmd/common/setup.go
@@ -7,8 +7,7 @@ import (
 	"github.com/defenseunicorns/lula/src/pkg/message"
 )
 
-func SetupClI(logLevel string) error {
-
+func SetupClI(logLevel string) {
 	match := map[string]message.LogLevel{
 		"warn":  message.WarnLevel,
 		"info":  message.InfoLevel,
@@ -37,6 +36,4 @@ func SetupClI(logLevel string) error {
 	}
 
 	printViperConfigUsed()
-
-	return nil
 }

--- a/src/cmd/console/console.go
+++ b/src/cmd/console/console.go
@@ -65,6 +65,9 @@ var consoleCmd = &cobra.Command{
 
 func ConsoleCommand() *cobra.Command {
 	consoleCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to the target OSCAL model")
-	consoleCmd.MarkFlagRequired("input-file")
+	err := consoleCmd.MarkFlagRequired("input-file")
+	if err != nil {
+		message.Fatal(err, "error initializing console command flags")
+	}
 	return consoleCmd
 }

--- a/src/cmd/dev/common.go
+++ b/src/cmd/dev/common.go
@@ -58,6 +58,7 @@ func ReadValidation(cmd *cobra.Command, spinner *message.Spinner, path string, t
 		go func() {
 			if timeout != NO_TIMEOUT {
 				time.Sleep(time.Duration(timeout) * time.Second)
+				//nolint:errcheck
 				cmd.Help()
 				message.Fatalf(fmt.Errorf("timed out waiting for stdin"), "timed out waiting for stdin")
 			}

--- a/src/cmd/dev/lint.go
+++ b/src/cmd/dev/lint.go
@@ -37,14 +37,18 @@ var lintCmd = &cobra.Command{
 		validationResults := DevLintCommand(lintOpts.InputFiles)
 
 		// If result file is specified, write the validation results to the file
+		var err error
 		if lintOpts.ResultFile != "" {
 			// If there is only one validation result, write it to the file
 			if len(validationResults) == 1 {
-				oscalValidation.WriteValidationResult(validationResults[0], lintOpts.ResultFile)
+				err = oscalValidation.WriteValidationResult(validationResults[0], lintOpts.ResultFile)
 			} else {
 				// If there are multiple validation results, write them to the file
-				oscalValidation.WriteValidationResults(validationResults, lintOpts.ResultFile)
+				err = oscalValidation.WriteValidationResults(validationResults, lintOpts.ResultFile)
 			}
+		}
+		if err != nil {
+			message.Fatal(err, "Error writing validation results")
 		}
 
 		// If there is at least one validation result that is not valid, exit with a fatal error

--- a/src/cmd/generate/generate.go
+++ b/src/cmd/generate/generate.go
@@ -118,7 +118,7 @@ var generateComponentCmd = &cobra.Command{
 		// Create a component definition from the catalog given required context
 		comp, err := oscal.ComponentFromCatalog(command, source, catalog, title, componentOpts.Requirements, remarks, componentOpts.Framework)
 		if err != nil {
-			message.Fatalf(err, fmt.Sprintf("error creating component - %s\n", err.Error()))
+			message.Fatalf(err, "error creating component - %s\n", err.Error())
 		}
 
 		var model = oscalTypes_1_1_2.OscalModels{

--- a/src/cmd/tools/compose.go
+++ b/src/cmd/tools/compose.go
@@ -87,7 +87,10 @@ func ComposeCommand() *cobra.Command {
 		},
 	}
 	composeCmd.Flags().StringVarP(&inputFile, "input-file", "f", "", "the path to the target OSCAL component definition")
-	composeCmd.MarkFlagRequired("input-file")
+	err := composeCmd.MarkFlagRequired("input-file")
+	if err != nil {
+		message.Fatal(err, "error initializing evaluate flags")
+	}
 	composeCmd.Flags().StringVarP(&outputFile, "output-file", "o", "", "the path to the output file. If not specified, the output file will be the original filename with `-composed` appended")
 	composeCmd.Flags().StringVarP(&renderTypeString, "render", "r", "", "values to render the template with, options are: masked, constants, non-sensitive, all")
 	composeCmd.Flags().StringSliceVarP(&setOpts, "set", "s", []string{}, "set value overrides for templated data")

--- a/src/cmd/tools/lint.go
+++ b/src/cmd/tools/lint.go
@@ -73,12 +73,16 @@ var lintCmd = &cobra.Command{
 
 		// If result file is specified, write the validation results to the file
 		if opts.ResultFile != "" {
+			var err error
 			// If there is only one validation result, write it to the file
 			if len(validationResults) == 1 {
-				oscalValidation.WriteValidationResult(validationResults[0], opts.ResultFile)
+				err = oscalValidation.WriteValidationResult(validationResults[0], opts.ResultFile)
 			} else {
 				// If there are multiple validation results, write them to the file
-				oscalValidation.WriteValidationResults(validationResults, opts.ResultFile)
+				err = oscalValidation.WriteValidationResults(validationResults, opts.ResultFile)
+			}
+			if err != nil {
+				message.Fatal(err, "Error writing validation results")
 			}
 		}
 

--- a/src/cmd/tools/template.go
+++ b/src/cmd/tools/template.go
@@ -96,7 +96,10 @@ func TemplateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&inputFile, "input-file", "f", "", "the path to the target artifact")
-	cmd.MarkFlagRequired("input-file")
+	err := cmd.MarkFlagRequired("input-file")
+	if err != nil {
+		message.Fatal(err, "error initializing template command flags")
+	}
 	cmd.Flags().StringVarP(&outputFile, "output-file", "o", "", "the path to the output file. If not specified, the output file will be directed to stdout")
 	cmd.Flags().StringSliceVarP(&setOpts, "set", "s", []string{}, "set a value in the template data")
 	cmd.Flags().StringVarP(&renderTypeString, "render", "r", "masked", "values to render the template with, options are: masked, constants, non-sensitive, all")

--- a/src/cmd/tools/upgrade.go
+++ b/src/cmd/tools/upgrade.go
@@ -73,7 +73,10 @@ func init() {
 	toolsCmd.AddCommand(upgradeCmd)
 
 	upgradeCmd.Flags().StringVarP(&upgradeOpts.InputFile, "input-file", "f", "", "the path to a oscal json schema file")
-	upgradeCmd.MarkFlagRequired("input-file")
+	err := upgradeCmd.MarkFlagRequired("input-file")
+	if err != nil {
+		message.Fatal(err, "error initializing upgrade command flags")
+	}
 	upgradeCmd.Flags().StringVarP(&upgradeOpts.OutputFile, "output-file", "o", "", "the path to write the linted oscal json schema file (default is the input file)")
 	upgradeCmd.Flags().StringVarP(&upgradeOpts.Version, "version", "v", versioning.GetLatestSupportedVersion(), "the version of the oscal schema to validate against (default is the latest supported version)")
 	upgradeCmd.Flags().StringVarP(&upgradeOpts.ValidationResult, "validation-result", "r", "", "the path to write the validation result file")

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/defenseunicorns/lula/src/pkg/common/composition"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/common/validation"
+	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/defenseunicorns/lula/src/types"
 	"github.com/spf13/cobra"
 )
@@ -113,7 +114,10 @@ func ValidateCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&outputFile, "output-file", "o", "", "the path to write assessment results. Creates a new file or appends to existing files")
 	cmd.Flags().StringVarP(&inputFile, "input-file", "f", "", "the path to the target OSCAL component definition")
-	cmd.MarkFlagRequired("input-file")
+	err := cmd.MarkFlagRequired("input-file")
+	if err != nil {
+		message.Fatal(err, "error initializing upgrade command flags")
+	}
 	cmd.Flags().StringVarP(&target, "target", "t", v.GetString(common.VTarget), "the specific control implementations or framework to validate against")
 	cmd.Flags().BoolVar(&confirmExecution, "confirm-execution", false, "confirm execution scripts run as part of the validation")
 	cmd.Flags().BoolVar(&runNonInteractively, "non-interactive", false, "run the command non-interactively")

--- a/src/pkg/common/composition/composition_test.go
+++ b/src/pkg/common/composition/composition_test.go
@@ -10,6 +10,7 @@ import (
 	oscalTypes_1_1_2 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/defenseunicorns/lula/src/internal/template"
 	"github.com/defenseunicorns/lula/src/pkg/common/composition"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -122,25 +123,11 @@ func TestComposeFromPath(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
-
-		if compDefComposed.Components == nil {
-			t.Error("expected the component definition to have components")
-		}
-
-		if compDefComposed.BackMatter == nil {
-			t.Error("expected the component definition to have back matter")
-		}
-
-		if compDefComposed.BackMatter.Resources == nil {
-			t.Error("expected the component definition to have back matter resources")
-		}
-
-		if len(*compDefComposed.BackMatter.Resources) != 0 {
-			t.Error("expected the back matter to contain 0 resources (validation)")
-		}
+		require.NotNil(t, compDefComposed)
+		require.NotNil(t, compDefComposed.Components)
+		require.NotNil(t, compDefComposed.BackMatter)
+		require.NotNil(t, compDefComposed.BackMatter.Resources)
+		require.Equal(t, len(*compDefComposed.BackMatter.Resources), 0)
 	})
 
 	// Test the templating of the component definition with nested templated imports
@@ -168,25 +155,11 @@ func TestComposeFromPath(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
-
-		if compDefComposed.Components == nil {
-			t.Error("expected the component definition to have components")
-		}
-
-		if compDefComposed.BackMatter == nil {
-			t.Error("expected the component definition to have back matter")
-		}
-
-		if compDefComposed.BackMatter.Resources == nil {
-			t.Fatalf("expected the component definition to have back matter resources")
-		}
-
-		if len(*compDefComposed.BackMatter.Resources) != 1 {
-			t.Error("expected the back matter to contain 1 resource (validation)")
-		}
+		require.NotNil(t, compDefComposed)
+		require.NotNil(t, compDefComposed.Components)
+		require.NotNil(t, compDefComposed.BackMatter)
+		require.NotNil(t, compDefComposed.BackMatter.Resources)
+		require.Len(t, *compDefComposed.BackMatter.Resources, 1)
 	})
 
 	t.Run("Errors when file does not exist", func(t *testing.T) {
@@ -240,9 +213,7 @@ func TestComposeComponentDefinitions(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		// Only the last-modified timestamp should be different
 		if !reflect.DeepEqual(*og.BackMatter, *compDefComposed.BackMatter) {
@@ -260,12 +231,10 @@ func TestComposeComponentDefinitions(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if reflect.DeepEqual(*og, *compDefComposed) {
-			t.Errorf("expected component definition to have changed.")
+			t.Error("expected component definition to have changed.")
 		}
 	})
 
@@ -279,9 +248,7 @@ func TestComposeComponentDefinitions(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if compDefComposed.Components == og.Components {
 			t.Error("expected there to be components")
@@ -302,9 +269,7 @@ func TestComposeComponentDefinitions(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if compDefComposed.Components == og.Components {
 			t.Error("expected there to be components")
@@ -332,9 +297,7 @@ func TestComposeComponentDefinitions(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if compDefComposed.Components == og.Components {
 			t.Error("expected there to be new components")
@@ -393,9 +356,7 @@ func TestComposeComponentValidations(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		// Only the last-modified timestamp should be different
 		if !reflect.DeepEqual(*og.BackMatter, *compDefComposed.BackMatter) {
@@ -413,9 +374,7 @@ func TestComposeComponentValidations(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if reflect.DeepEqual(*og, *compDefComposed) {
 			t.Error("expected the component definition to be changed")
@@ -440,9 +399,7 @@ func TestComposeComponentValidations(t *testing.T) {
 		}
 
 		compDefComposed := model.ComponentDefinition
-		if compDefComposed == nil {
-			t.Error("expected the component definition to be non-nil")
-		}
+		require.NotNil(t, compDefComposed)
 
 		if reflect.DeepEqual(*og, *compDefComposed) {
 			t.Error("expected the component definition to be changed")

--- a/src/pkg/common/network/network.go
+++ b/src/pkg/common/network/network.go
@@ -92,7 +92,10 @@ func WithBaseDir(baseDir string) FetchOption {
 func Fetch(inputURL string, opts ...FetchOption) (bytes []byte, err error) {
 	config := &fetchOpts{}
 	for _, opt := range opts {
-		opt(config)
+		err = opt(config)
+		if err != nil {
+			return bytes, err
+		}
 	}
 
 	url, checksum, err := ParseChecksum(inputURL)

--- a/src/pkg/common/result/result-comparison.go
+++ b/src/pkg/common/result/result-comparison.go
@@ -27,7 +27,7 @@ type ResultComparison struct {
 }
 
 // PrintResultComparisonTable prints a table output of compared results
-func (r ResultComparison) PrintResultComparisonTable(changedOnly bool) {
+func (r ResultComparison) PrintResultComparisonTable(changedOnly bool) error {
 	header := []string{"Observation", "Satisfied", "Change", "New Remarks", "Threshold Remarks"}
 	rows := make([][]string, 0)
 	columnSize := []int{20, 10, 15, 25, 30}
@@ -46,14 +46,18 @@ func (r ResultComparison) PrintResultComparisonTable(changedOnly bool) {
 		})
 	}
 	if len(rows) != 0 {
-		message.Table(header, rows, columnSize)
+		err := message.Table(header, rows, columnSize)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type ResultComparisonMap map[string]ResultComparison
 
 // PrintObservationComparisonTable prints a table output of compared observations, per control
-func (rm ResultComparisonMap) PrintObservationComparisonTable(changedOnly bool, skipRemoved bool, failedOnly bool) []string {
+func (rm ResultComparisonMap) PrintObservationComparisonTable(changedOnly bool, skipRemoved bool, failedOnly bool) ([]string, error) {
 	header := []string{"Control ID(s)", "Observation", "Satisfied", "Change", "New Remarks", "Threshold Remarks"}
 	rows := make([][]string, 0)
 	columnSize := []int{10, 20, 5, 15, 25, 25}
@@ -81,11 +85,12 @@ func (rm ResultComparisonMap) PrintObservationComparisonTable(changedOnly bool, 
 			observationPair.ComparedObservation,
 		})
 	}
+	var err error
 	if len(rows) != 0 {
-		message.Table(header, rows, columnSize)
+		err = message.Table(header, rows, columnSize)
 	}
 
-	return noObservations
+	return noObservations, err
 }
 
 // NewResultComparisonMap -> create a map of result comparisons from two OSCAL results
@@ -151,7 +156,7 @@ func Collapse(mapResultComparisonMap map[string]ResultComparisonMap) ResultCompa
 
 // Refactor observations by controls
 func RefactorObservationsByControls(ResultComparisonMap ResultComparisonMap) (map[string]ObservationPair, map[string][]string, []string) {
-	// for each category, add the observationpair and add controlId
+	// for each category, add the ObservationPair and add controlId
 	observationPairMap := make(map[string]ObservationPair)
 	controlObservationMap := make(map[string][]string)
 	noObservations := make([]string, 0)

--- a/src/pkg/common/validation-store/validation-store_test.go
+++ b/src/pkg/common/validation-store/validation-store_test.go
@@ -10,6 +10,7 @@ import (
 	validationstore "github.com/defenseunicorns/lula/src/pkg/common/validation-store"
 	"github.com/defenseunicorns/lula/src/pkg/message"
 	"github.com/defenseunicorns/lula/src/types"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -116,7 +117,8 @@ func TestDryRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := validationstore.NewValidationStore()
 			for _, validation := range tt.validations {
-				v.AddValidation(&validation)
+				_, err := v.AddValidation(&validation)
+				require.NoError(t, err)
 			}
 
 			executable, _ := v.DryRun()

--- a/src/pkg/common/validation/validation.go
+++ b/src/pkg/common/validation/validation.go
@@ -173,9 +173,10 @@ func (v *Validator) ValidateOnControlImplementations(ctx context.Context, contro
 		})
 	}
 
+	var err error
 	if len(rows) != 0 {
-		message.Table(header, rows, columnSize)
+		err = message.Table(header, rows, columnSize)
 	}
 
-	return findings, observations, nil
+	return findings, observations, err
 }

--- a/src/pkg/domains/api/api.go
+++ b/src/pkg/domains/api/api.go
@@ -23,7 +23,7 @@ func MakeRequests(Requests []Request) (types.DomainResources, error) {
 		}
 		if resp.StatusCode != 200 {
 			return nil,
-				fmt.Errorf("expected status code 200 but got %d\n", resp.StatusCode)
+				fmt.Errorf("expected status code 200 but got %d", resp.StatusCode)
 		}
 
 		defer resp.Body.Close()
@@ -36,7 +36,10 @@ func MakeRequests(Requests []Request) (types.DomainResources, error) {
 		if contentType == "application/json" {
 
 			var prettyBuff bytes.Buffer
-			json.Indent(&prettyBuff, body, "", "  ")
+			err := json.Indent(&prettyBuff, body, "", "  ")
+			if err != nil {
+				return nil, err
+			}
 			prettyJson := prettyBuff.String()
 
 			var tempData interface{}

--- a/src/pkg/message/interactive.go
+++ b/src/pkg/message/interactive.go
@@ -1,8 +1,6 @@
 package message
 
 import (
-	"fmt"
-
 	"github.com/pterm/pterm"
 )
 
@@ -10,7 +8,7 @@ func PromptForConfirmation(spinner *Spinner) bool {
 	// Prompt the user to confirm the action
 	if spinner != nil {
 		spinnerText := spinner.Pause()
-		defer spinner.Updatef(fmt.Sprintf("%s\n", spinnerText))
+		defer spinner.Updatef("%s\n", spinnerText)
 	}
 
 	confirmation := pterm.DefaultInteractiveConfirm.WithDefaultText("Do you want to run executable validations?")

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -319,7 +319,7 @@ func Truncate(text string, length int, invert bool) string {
 
 // Table prints a padded table containing the specified header and data
 // Note - columnSize should be an array of ints that add up to 100
-func Table(header []string, data [][]string, columnSize []int) {
+func Table(header []string, data [][]string, columnSize []int) error {
 	pterm.Println()
 	termWidth := pterm.GetTerminalWidth() - 10 // Subtract 10 for padding
 
@@ -342,7 +342,7 @@ func Table(header []string, data [][]string, columnSize []int) {
 		table = append(table, pterm.TableData{row}...)
 	}
 
-	pterm.DefaultTable.WithHasHeader().WithData(table).WithRowSeparator("-").Render()
+	return pterm.DefaultTable.WithHasHeader().WithData(table).WithRowSeparator("-").Render()
 }
 
 // Add line breaks for table

--- a/src/pkg/message/spinner.go
+++ b/src/pkg/message/spinner.go
@@ -105,7 +105,8 @@ func (p *Spinner) Updatef(format string, a ...any) {
 // Stop the spinner.
 func (p *Spinner) Stop() {
 	if p.spinner != nil && p.spinner.IsActive {
-		_ = p.spinner.Stop()
+		//nolint:errcheck
+		p.spinner.Stop()
 	}
 	activeSpinner = nil
 }
@@ -151,7 +152,8 @@ func (p *Spinner) Fatal(err error) {
 func (p *Spinner) Fatalf(err error, format string, a ...any) {
 	if p.spinner != nil {
 		p.spinner.RemoveWhenDone = true
-		_ = p.spinner.Stop()
+		//nolint:errcheck
+		p.spinner.Stop()
 		activeSpinner = nil
 	}
 	Fatalf(err, format, a...)
@@ -162,6 +164,7 @@ func (p *Spinner) Pause() string {
 	var spinnerText string
 	if p.spinner != nil && p.spinner.IsActive {
 		spinnerText = p.spinner.Text
+		//nolint:errcheck
 		p.spinner.Stop()
 	}
 	return spinnerText

--- a/src/types/types_test.go
+++ b/src/types/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/defenseunicorns/lula/src/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetDomainResourcesAsJSON(t *testing.T) {
@@ -51,9 +52,11 @@ func TestGetDomainResourcesAsJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.validation.GetDomainResourcesAsJSON()
 			var jsonWant map[string]interface{}
-			json.Unmarshal(tt.want, &jsonWant)
+			err := json.Unmarshal(tt.want, &jsonWant)
+			require.NoError(t, err)
 			var jsonGot map[string]interface{}
-			json.Unmarshal(got, &jsonGot)
+			err = json.Unmarshal(got, &jsonGot)
+			require.NoError(t, err)
 			if !reflect.DeepEqual(jsonGot, jsonWant) {
 				t.Errorf("GetDomainResourcesAsJSON() got = %v, want %v", jsonGot, jsonWant)
 			}


### PR DESCRIPTION
This PR adds error checking everywhere we were skipping it, and modifies some tests that would return an _error_ if the checked value was nil instead of failing the test, and then go on to inspect the (potentially nil) value. Minor stuff!

There were exceptions where a given method would never return an error; in one case (external method) I added the `nolint` directive, but since I am the only one running that linter right now we could leave it out and just ignore it. In another case I removed the error return, since we never returned an error anyway. 

I'd like to eventually get the golangci-lint linter configured and running in our CI - there are a couple of checks I appreciate, and I see we have cspell so we could get that dictionary updated and running against the whole codebase, etc. I don't have a vision for initial set up though, but this seemed worth doing even in isolation.

I didn't touch anything in the `tui` package since @meganwolf0 has a bunch of work in flight right now!