### PR TITLE
DRAFT feat(domains): api domain options

### DIFF
--- a/src/pkg/common/schemas/validation.json
+++ b/src/pkg/common/schemas/validation.json
@@ -362,8 +362,45 @@
                             "url": {
                                 "type": "string",
                                 "format": "uri"
+                            },
+                            "method": {
+                                "type": "string",
+                                "enum": ["Get", "Head", "Post", "PostForm"],
+                                "default": "Get"
+                            },
+                            "body": {
+                                "type": "string"
+                            },
+                            "parameters": {
+                                "type": "object",
+                                "additionalProperties": { "type": "string"}
+                            },
+                            "options": {
+                                "$ref": "#/definitions/api-options"
                             }
                         }
+                    },
+                    "required": ["name", "url"]
+                },
+                "options": {
+                    "$ref": "#/definitions/api-options"
+                }
+            },
+            "required": ["requests"]
+        },
+        "api-options": {
+            "type": "object",
+            "properties": {
+                "timeout": {
+                    "type": "integer"
+                },
+                "proxy": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/src/pkg/domains/api/spec.go
+++ b/src/pkg/domains/api/spec.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+)
+
+func validateSpec(spec *ApiSpec) error {
+	if spec == nil {
+		return errors.New("spec is required")
+	}
+	if len(spec.Requests) == 0 {
+		return errors.New("some requests must be specified")
+	}
+	for _, request := range spec.Requests {
+		if request.Name == "" {
+			return errors.New("request name cannot be empty")
+		}
+		if request.URL == "" {
+			return errors.New("request url cannot be empty")
+		}
+		if request.Method != "" {
+			if request.Method != "Get" && request.Method != "Head" && request.Method != "Post" && request.Method != "PostForm" {
+				return fmt.Errorf("unsupported method: %s", request.Method)
+			}
+		}
+	}
+	return nil
+}

--- a/src/pkg/domains/api/types.go
+++ b/src/pkg/domains/api/types.go
@@ -42,18 +42,19 @@ type ApiSpec struct {
 
 // Request is a single API request
 type Request struct {
-	Name   string            `json:"name" yaml:"name"`
-	URL    string            `json:"url" yaml:"url"`
-	Method string            `json:"method,omitempty" yaml:"method,omitempty"`
-	Body   string            `json:"body,omitempty" yaml:"body,omitempty"`
-	Params map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Name         string            `json:"name" yaml:"name"`
+	URL          string            `json:"url" yaml:"url"`
+	Method       string            `json:"method,omitempty" yaml:"method,omitempty"`
+	IsExecutable bool              `json:"executable,omitempty" yaml:"executable,omitempty"`
+	Body         string            `json:"body,omitempty" yaml:"body,omitempty"`
+	Params       map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	// ApiOpts specific to this request
 	Options *ApiOpts `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 type ApiOpts struct {
 	// Timeout in seconds
-	Timeout int64    `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Timeout string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Proxy   string   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 	Headers []string `json:"headers,omitempty" yaml:"headers,omitempty"`
 }

--- a/src/pkg/domains/api/types.go
+++ b/src/pkg/domains/api/types.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/defenseunicorns/lula/src/types"
 )
@@ -15,20 +14,9 @@ type ApiDomain struct {
 
 func CreateApiDomain(spec *ApiSpec) (types.Domain, error) {
 	// Check validity of spec
-	if spec == nil {
-		return nil, fmt.Errorf("spec is nil")
-	}
-
-	if len(spec.Requests) == 0 {
-		return nil, fmt.Errorf("some requests must be specified")
-	}
-	for _, request := range spec.Requests {
-		if request.Name == "" {
-			return nil, fmt.Errorf("request name cannot be empty")
-		}
-		if request.URL == "" {
-			return nil, fmt.Errorf("request url cannot be empty")
-		}
+	err := validateSpec(spec)
+	if err != nil {
+		return nil, err
 	}
 
 	return ApiDomain{
@@ -36,8 +24,8 @@ func CreateApiDomain(spec *ApiSpec) (types.Domain, error) {
 	}, nil
 }
 
-func (a ApiDomain) GetResources(_ context.Context) (types.DomainResources, error) {
-	return MakeRequests(a.Spec.Requests)
+func (a ApiDomain) GetResources(ctx context.Context) (types.DomainResources, error) {
+	return a.makeRequests(ctx)
 }
 
 func (a ApiDomain) IsExecutable() bool {
@@ -48,10 +36,24 @@ func (a ApiDomain) IsExecutable() bool {
 // ApiSpec contains a list of API requests
 type ApiSpec struct {
 	Requests []Request `mapstructure:"requests" json:"requests" yaml:"requests"`
+	// Opts will be applied to all requests, except those which have their own specified ApiOpts
+	Options *ApiOpts `mapstructure:"options" json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 // Request is a single API request
 type Request struct {
-	Name string `json:"name" yaml:"name"`
-	URL  string `json:"url" yaml:"url"`
+	Name   string            `json:"name" yaml:"name"`
+	URL    string            `json:"url" yaml:"url"`
+	Method string            `json:"method,omitempty" yaml:"method,omitempty"`
+	Body   string            `json:"body,omitempty" yaml:"body,omitempty"`
+	Params map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	// ApiOpts specific to this request
+	Options *ApiOpts `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+type ApiOpts struct {
+	// Timeout in seconds
+	Timeout int64    `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Proxy   string   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	Headers []string `json:"headers,omitempty" yaml:"headers,omitempty"`
 }


### PR DESCRIPTION
This draft pull request supplements the (internal) design doc for the API options. No real new functionality is implemented in this PR yet, just refactoring to add the options and show where they might go.

Note for reviewers: Take a look at the new `ApiOpts` and the fields added to the `Request` struct (`ApiOpts` is a field too, any of the APIOpts can be overridden on a per-request basis). The items in ApiOpts have the potential to apply to every API request - for e.g. proxy and timeouts - while the added fields in requests are options that are (most likely to be) configured on a per-API basis. 

This is not complete, I have not added every option from the design doc yet. I was working through them and got thinking about the delineation between client and request options, and here we are.
