### PR TITLE
feat(api domain): accept any API response and include reponse status code in domain resources

### DIFF
--- a/docs/reference/domains/api-domain.md
+++ b/docs/reference/domains/api-domain.md
@@ -45,4 +45,13 @@ domain:
 
 ## API Domain Resources
 
-The API response body is serialized into a json object with the request Name as the top-level key. The API status code is included in the output domain resources.
+The API response body is serialized into a json object with the Request's Name as the top-level key. The API status code is included in the output domain resources.
+
+Example output:
+
+```json
+"healthcheck": {
+  "status": 200,
+  "healthy": "ok"
+}
+```

--- a/docs/reference/domains/api-domain.md
+++ b/docs/reference/domains/api-domain.md
@@ -2,7 +2,7 @@
 
 The API Domain allows for collection of data (via HTTP Get Requests) generically from API endpoints. 
 
-# Specification
+## Specification
 The API domain Specification accepts a list of `Requests` and an `Options` block. `Options` can be configured at the top-level and will apply to all requests except those which have embedded `Options`. `Request`-level options will *override* top-level `Options`.
 
 
@@ -42,3 +42,7 @@ domain:
       - name: "readycheck"
       # etc ...
 ```
+
+## API Domain Resources
+
+The API response body is serialized into a json object with the request Name as the top-level key. The API status code is included in the output domain resources.

--- a/src/pkg/domains/api/api.go
+++ b/src/pkg/domains/api/api.go
@@ -31,17 +31,19 @@ func (a ApiDomain) makeRequests(ctx context.Context) (types.DomainResources, err
 		defaultClient := clientFromOpts(defaultOpts)
 
 		for _, request := range a.Spec.Requests {
-			var responseType interface{}
+			var responseType map[string]interface{}
 			var err error
+			var status int
 			if request.Options == nil {
-				responseType, err = doHTTPReq(ctx, defaultClient, *request.reqURL, defaultOpts.Headers, request.reqParameters, responseType)
+				responseType, status, err = doHTTPReq(ctx, defaultClient, *request.reqURL, defaultOpts.Headers, request.reqParameters, responseType)
 			} else {
 				client := clientFromOpts(request.Options)
-				responseType, err = doHTTPReq(ctx, client, *request.reqURL, request.Options.Headers, request.reqParameters, responseType)
+				responseType, status, err = doHTTPReq(ctx, client, *request.reqURL, request.Options.Headers, request.reqParameters, responseType)
 			}
 			if err != nil {
 				return collection, err
 			}
+			responseType["status"] = status
 			collection[request.Name] = responseType
 		}
 		return collection, nil

--- a/src/pkg/domains/api/types_test.go
+++ b/src/pkg/domains/api/types_test.go
@@ -72,7 +72,7 @@ func TestCreateApiDomain(t *testing.T) {
 	}
 }
 
-func TestApiDomain(t *testing.T) {
+func TestGetResources(t *testing.T) {
 	respBytes := []byte(`{"healthcheck": "ok"}`)
 	// unmarshal the response
 	var resp map[string]interface{}
@@ -131,6 +131,10 @@ func TestApiDomain(t *testing.T) {
 		require.NoError(t, err) // the spec is correct
 		drs, err := api.GetResources(context.Background())
 		require.Error(t, err)
-		require.Empty(t, drs)
+		require.Equal(t, drs, types.DomainResources{
+			apiReqName: types.DomainResources{
+				"status": 400,
+			},
+		})
 	})
 }

--- a/src/pkg/domains/api/types_test.go
+++ b/src/pkg/domains/api/types_test.go
@@ -73,13 +73,13 @@ func TestCreateApiDomain(t *testing.T) {
 }
 
 func TestApiDomain(t *testing.T) {
-	respBytes := []byte(`{"status":"ok"}`)
+	respBytes := []byte(`{"healthcheck": "ok"}`)
 	// unmarshal the response
 	var resp map[string]interface{}
 	err := json.Unmarshal(respBytes, &resp)
 	require.NoError(t, err)
 
-	name := "test"
+	apiReqName := "test"
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Accept") != "application/json" {
 			w.WriteHeader(http.StatusBadRequest)
@@ -97,7 +97,7 @@ func TestApiDomain(t *testing.T) {
 		api, err := CreateApiDomain(&ApiSpec{
 			Requests: []Request{
 				{
-					Name:   name,
+					Name:   apiReqName,
 					URL:    svr.URL,
 					Params: map[string]string{"label": "test"},
 					Options: &ApiOpts{
@@ -110,14 +110,19 @@ func TestApiDomain(t *testing.T) {
 		require.NoError(t, err)
 		drs, err := api.GetResources(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, drs, types.DomainResources{name: resp})
+		require.Equal(t, drs, types.DomainResources{
+			apiReqName: map[string]interface{}{
+				"healthcheck": "ok",
+				"status":      200,
+			},
+		})
 	})
 
 	t.Run("fail", func(t *testing.T) {
 		api, err := CreateApiDomain(&ApiSpec{
 			Requests: []Request{
 				{
-					Name: name,
+					Name: apiReqName,
 					URL:  svr.URL,
 				},
 			},


### PR DESCRIPTION
## Description
The API domain will now accept any response code from an API call, instead of returning an error on anything other than 200. The response status code has been added to the returned domain resources, so users can write validations that an API returned the expected response.

## Related Issue

Fixes #787

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed