### PR TITLE
chore: declare top-level read permissions in workflows

### DIFF
--- a/.github/workflows/goreleaser-check.yaml
+++ b/.github/workflows/goreleaser-check.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - '.goreleaser.yaml'
 
+# Permissions are granted per-job when write access is needed
+permissions: read-all
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
 
-# Permissions are granted per-job when write access is needed
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   tag-new-version:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
 
-permissions: 
-  contents: read
+# Permissions are granted per-job when write access is needed
+permissions: read-all
 
 jobs:
   tag-new-version:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Publish Lula Packages on Tag
 
-# Permissions are granted per-job when write access is needed
-permissions: read-all
+permissions:
+  contents: read
+  packages: read
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
 name: Publish Lula Packages on Tag
 
-permissions:
-  contents: read
-  packages: read
+# Permissions are granted per-job when write access is needed
+permissions: read-all
 
 on:
   push:


### PR DESCRIPTION
## Description

This is part of working through the results from https://github.com/defenseunicorns/lula/security/code-scanning (#730)
The permissions appeared to be set properly at the job-level already, this PR just adds top-level read only  permissions to jobs as a safety precaution.

(sorry for the noise, got a bit turned around)
...

## Related Issue
Relates to #730