### PR TITLE
fix(api domain)!: improve status handling in API Domain; do not return an error on 404

### DIFF
--- a/src/pkg/domains/api/api.go
+++ b/src/pkg/domains/api/api.go
@@ -13,9 +13,10 @@ import (
 )
 
 type APIResponse struct {
-	Status   int
-	Raw      json.RawMessage
-	Response any
+	StatusCode int
+	Status     string
+	Raw        json.RawMessage
+	Response   any
 }
 
 func (a ApiDomain) makeRequests(ctx context.Context) (types.DomainResources, error) {
@@ -63,11 +64,13 @@ func (a ApiDomain) makeRequests(ctx context.Context) (types.DomainResources, err
 				errs = errors.Join(errs, err)
 			}
 			if response != nil {
-				collection[request.Name] = types.DomainResources{
-					"status":   response.Status,
-					"raw":      response.Raw,
-					"response": response.Response,
+				dr := types.DomainResources{
+					"status":     response.Status,
+					"statuscode": response.StatusCode,
+					"raw":        response.Raw,
+					"response":   response.Response,
 				}
+				collection[request.Name] = dr
 			} else {
 				// If the entire response is empty, return a validly empty resource
 				collection[request.Name] = types.DomainResources{"status": 0}

--- a/src/pkg/domains/api/types_test.go
+++ b/src/pkg/domains/api/types_test.go
@@ -118,7 +118,8 @@ func TestGetResources(t *testing.T) {
 				"response": map[string]interface{}{
 					"healthcheck": "ok",
 				},
-				"status": 200,
+				"status":     "200 OK",
+				"statuscode": 200,
 			}}
 		require.Equal(t, want, drs)
 	})
@@ -135,13 +136,15 @@ func TestGetResources(t *testing.T) {
 
 		require.NoError(t, err) // the spec is correct
 		drs, err := api.GetResources(context.Background())
-		require.Error(t, err)
-		require.Equal(t, drs, types.DomainResources{
+		require.NoError(t, err)
+		require.Equal(t, types.DomainResources{
 			apiReqName: types.DomainResources{
-				"status":   400,
-				"raw":      json.RawMessage{},
-				"response": nil,
-			},
-		})
+				"statuscode": 400,
+				"status":     "400 Bad Request",
+				"response":   nil,
+				"raw":        json.RawMessage(nil),
+			}},
+			drs,
+		)
 	})
 }


### PR DESCRIPTION
Properly handle cases where a non-200 status code is returned and the status text is in the response body - otherwise basically any error would end up in the body as a string (thanks, http/2) and result in an unmarshalling error.

Changes:
- added a "status" field, which is populated with the http.Status if included in the response, or the text from the http.StatusCode if not.
- don't error on a 404 (I swear I did that already, so I guess I did it for reals this time)
- don't try to unmarshal the body into a json object if the return isn't a 2XX

I'm sure I'm missing more edge cases, and welcome any suggestions, but hopefully this is better!

There is a bit of a breaking change, excep;t it's the one I thought I'd already tackled (missed a big one, I guess): we don't return an error on a 404 response (or, theoretically, any other response that isn't very genuinely invalid - the bits I already took care of?); instead we return a DR with the status code and message.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed