### PR TITLE
feat: updated merge component defn

### DIFF
--- a/src/pkg/common/composition/composition.go
+++ b/src/pkg/common/composition/composition.go
@@ -11,12 +11,13 @@ import (
 	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	"github.com/defenseunicorns/go-oscal/src/pkg/versioning"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+
 	"github.com/defenseunicorns/lula/src/internal/template"
 	"github.com/defenseunicorns/lula/src/pkg/common"
 	"github.com/defenseunicorns/lula/src/pkg/common/network"
 	"github.com/defenseunicorns/lula/src/pkg/common/oscal"
 	"github.com/defenseunicorns/lula/src/pkg/message"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 type RenderedContent string
@@ -124,7 +125,7 @@ func (c *Composer) ComposeComponentDefinitions(ctx context.Context, compDef *osc
 				}
 
 				// Merge the component definitions
-				compDef, err = oscal.MergeComponentDefinitions(compDef, importDef)
+				err = oscal.MergeComponentDefinitions(compDef, importDef)
 				if err != nil {
 					return err
 				}

--- a/src/pkg/common/oscal/complete-schema.go
+++ b/src/pkg/common/oscal/complete-schema.go
@@ -216,12 +216,10 @@ func MergeOscalModels(existingModel *oscalTypes.OscalModels, newModel *oscalType
 			return newModel, nil
 		}
 
-		merged, err := MergeComponentDefinitions(existingModel.ComponentDefinition, newModel.ComponentDefinition)
+		err := MergeComponentDefinitions(existingModel.ComponentDefinition, newModel.ComponentDefinition)
 		if err != nil {
 			return nil, err
 		}
-		// Re-assign after processing errors
-		existingModel.ComponentDefinition = merged
 	}
 
 	// Assessment Results

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -119,25 +119,50 @@ func MergeVariadicComponentDefinition(compDefs ...*oscalTypes.ComponentDefinitio
 
 // This function should perform a merge of two component-definitions where maintaining the original component-definition is the primary concern.
 func MergeComponentDefinitions(original *oscalTypes.ComponentDefinition, latest *oscalTypes.ComponentDefinition) (*oscalTypes.ComponentDefinition, error) {
-
-	originalMap := make(map[string]oscalTypes.DefinedComponent)
-
-	if original.Components == nil {
+	// Nil check on original and latest
+	if original == nil {
 		return original, fmt.Errorf("original component-definition is nil")
 	}
 
-	if latest.Components == nil {
+	if latest == nil {
 		return original, fmt.Errorf("latest component-definition is nil")
 	}
 
-	for _, component := range *original.Components {
-		originalMap[component.Title] = component
+	// merge the component-definition.components
+	if original.Components != nil && latest.Components != nil {
+		original.Components = mergeDefinedComponents(original.Components, latest.Components)
+	} else if original.Components == nil && latest.Components != nil {
+		original.Components = latest.Components
+	}
+
+	// merge the component-definition.back-matter resources
+	if original.BackMatter != nil && latest.BackMatter != nil {
+		original.BackMatter = &oscalTypes.BackMatter{
+			Resources: mergeResources(original.BackMatter.Resources, latest.BackMatter.Resources),
+		}
+	} else if original.BackMatter == nil && latest.BackMatter != nil {
+		original.BackMatter = latest.BackMatter
+	}
+
+	// Artifact will be modified - need to update the timestamp and UUID
+	original.Metadata.LastModified = time.Now()
+	original.UUID = uuid.NewUUID()
+
+	return original, nil
+
+}
+
+func mergeDefinedComponents(original *[]oscalTypes.DefinedComponent, latest *[]oscalTypes.DefinedComponent) *[]oscalTypes.DefinedComponent {
+	originalMap := make(map[string]oscalTypes.DefinedComponent)
+
+	for _, component := range *original {
+		originalMap[component.UUID] = component
 	}
 
 	latestMap := make(map[string]oscalTypes.DefinedComponent)
 
-	for _, component := range *latest.Components {
-		latestMap[component.Title] = component
+	for _, component := range *latest {
+		latestMap[component.UUID] = component
 	}
 
 	tempItems := make([]oscalTypes.DefinedComponent, 0)
@@ -157,23 +182,7 @@ func MergeComponentDefinitions(original *oscalTypes.ComponentDefinition, latest 
 		tempItems = append(tempItems, item)
 	}
 
-	// merge the back-matter resources
-	if original.BackMatter != nil && latest.BackMatter != nil {
-		original.BackMatter = &oscalTypes.BackMatter{
-			Resources: mergeResources(original.BackMatter.Resources, latest.BackMatter.Resources),
-		}
-	} else if original.BackMatter == nil && latest.BackMatter != nil {
-		original.BackMatter = latest.BackMatter
-	}
-
-	original.Components = &tempItems
-	original.Metadata.LastModified = time.Now()
-
-	// Artifact will be modified - need to update the UUID
-	original.UUID = uuid.NewUUID()
-
-	return original, nil
-
+	return &tempItems
 }
 
 func mergeComponents(original *oscalTypes.DefinedComponent, latest *oscalTypes.DefinedComponent) *oscalTypes.DefinedComponent {

--- a/src/pkg/common/oscal/component.go
+++ b/src/pkg/common/oscal/component.go
@@ -93,11 +93,11 @@ func (c *ComponentDefinition) HandleExisting(path string) error {
 		if err != nil {
 			return err
 		}
-		model, err := MergeComponentDefinitions(compDef.Model, c.Model)
+		err = MergeComponentDefinitions(compDef.Model, c.Model)
 		if err != nil {
 			return err
 		}
-		c.Model = model
+		c.Model = compDef.Model
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func MergeVariadicComponentDefinition(compDefs ...*oscalTypes.ComponentDefinitio
 		if mergedCompDef == nil {
 			mergedCompDef = compDef
 		} else {
-			mergedCompDef, err = MergeComponentDefinitions(mergedCompDef, compDef)
+			err = MergeComponentDefinitions(mergedCompDef, compDef)
 			if err != nil {
 				return nil, err
 			}
@@ -118,14 +118,14 @@ func MergeVariadicComponentDefinition(compDefs ...*oscalTypes.ComponentDefinitio
 }
 
 // This function should perform a merge of two component-definitions where maintaining the original component-definition is the primary concern.
-func MergeComponentDefinitions(original *oscalTypes.ComponentDefinition, latest *oscalTypes.ComponentDefinition) (*oscalTypes.ComponentDefinition, error) {
+func MergeComponentDefinitions(original *oscalTypes.ComponentDefinition, latest *oscalTypes.ComponentDefinition) error {
 	// Nil check on original and latest
 	if original == nil {
-		return original, fmt.Errorf("original component-definition is nil")
+		return fmt.Errorf("original component-definition is nil")
 	}
 
 	if latest == nil {
-		return original, fmt.Errorf("latest component-definition is nil")
+		return fmt.Errorf("latest component-definition is nil")
 	}
 
 	// merge the component-definition.components
@@ -148,7 +148,7 @@ func MergeComponentDefinitions(original *oscalTypes.ComponentDefinition, latest 
 	original.Metadata.LastModified = time.Now()
 	original.UUID = uuid.NewUUID()
 
-	return original, nil
+	return nil
 
 }
 

--- a/src/pkg/common/oscal/component_test.go
+++ b/src/pkg/common/oscal/component_test.go
@@ -331,7 +331,7 @@ func TestMergeComponentDefinitions(t *testing.T) {
 				(*generated.Model.Components)[0].UUID = (*validComponent.Components)[0].UUID
 			}
 
-			merged, err := oscal.MergeComponentDefinitions(validComponent, generated.Model)
+			err = oscal.MergeComponentDefinitions(validComponent, generated.Model)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MergeComponentDefinitions() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -342,9 +342,9 @@ func TestMergeComponentDefinitions(t *testing.T) {
 			}
 
 			// Perform checks on quantities
-			components := (*merged.Components)
+			components := (*validComponent.Components)
 			if len(components) != tt.expectedComponents {
-				t.Errorf("MergeComponentDefinitions() expected %v components, got %v", tt.expectedComponents, len((*merged.Components)))
+				t.Errorf("MergeComponentDefinitions() expected %v components, got %v", tt.expectedComponents, len((*validComponent.Components)))
 			}
 			controlImplementations := make([]oscalTypes.ControlImplementationSet, 0)
 			var targetComponent oscalTypes.DefinedComponent

--- a/src/pkg/common/oscal/component_test.go
+++ b/src/pkg/common/oscal/component_test.go
@@ -249,6 +249,7 @@ func TestMergeComponentDefinitions(t *testing.T) {
 		expectedImplementedRequirements       int
 		expectedTargetControlImplementations  int
 		expectedTargetImplementedRequirements int
+		uniqueComponent                       bool
 		wantErr                               bool
 	}{
 		{
@@ -262,6 +263,7 @@ func TestMergeComponentDefinitions(t *testing.T) {
 			expectedImplementedRequirements:       4,
 			expectedTargetControlImplementations:  1,
 			expectedTargetImplementedRequirements: 4,
+			uniqueComponent:                       false,
 			wantErr:                               false,
 		},
 		{
@@ -275,6 +277,7 @@ func TestMergeComponentDefinitions(t *testing.T) {
 			expectedImplementedRequirements:       6,
 			expectedTargetControlImplementations:  1,
 			expectedTargetImplementedRequirements: 6,
+			uniqueComponent:                       false,
 			wantErr:                               false,
 		},
 		{
@@ -288,6 +291,7 @@ func TestMergeComponentDefinitions(t *testing.T) {
 			expectedControlImplementations:        2,
 			expectedTargetImplementedRequirements: 4,
 			expectedTargetControlImplementations:  1,
+			uniqueComponent:                       true,
 			wantErr:                               false,
 		},
 		{
@@ -320,6 +324,11 @@ func TestMergeComponentDefinitions(t *testing.T) {
 					return
 				}
 				t.Errorf("ComponentFromCatalog() generated should not be nil")
+			}
+
+			// Check if component is supposed to be unique - override UUID if not
+			if !tt.uniqueComponent {
+				(*generated.Model.Components)[0].UUID = (*validComponent.Components)[0].UUID
 			}
 
 			merged, err := oscal.MergeComponentDefinitions(validComponent, generated.Model)


### PR DESCRIPTION
## Description

Updates to the merge component definition function:
* Moves the merge of "oscal.DefinedComponents" out of the main function to allow merge on files with none defined (since this is valid OSCAL and is needed for the import component definitions methods)
* Changed merging on unique component titles to merging on unique component UUIDs

**Notes/Questions to Reviewers**
* Initially I thought the update to the merge on UUID would have to change using the `ComponentFromCatalog` method to create test data, but was able to bandaid that test method with a simple UUID copy if the component is not `unique`, as set in the test set-up. This is probably a bit flimsy, but works for our test cases... a potentially better solution would be to re-write that test to not use that method to generate data - I opted for the simpler approach but am open to revising it :)

## Related Issue

Fixes #893 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- (n/a)[Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed