### PR TITLE
fix: update to a version instead of main

### DIFF
--- a/.github/workflows/triage-label.yaml
+++ b/.github/workflows/triage-label.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Add triage label
-      uses: actions/github-script@d70566966bbb446d06887700f68d905602745985
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const issueNumber = context.issue.number;


### PR DESCRIPTION
## Description

Updated the triage label action to use github script on a version instead of main.

## Related Issue

Fixes #909 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Schema Updates](https://github.com/defenseunicorns/lula/blob/main/docs/community-and-contribution/schema-updates.md) applied
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed